### PR TITLE
chore(release): v1.0.0-beta.3

### DIFF
--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -721,7 +721,10 @@ class AdminCore {
 
 		$result = $this->pdc_client->purchase_order_item( $order_item_id, $pdc_product_config );
 		if ( is_wp_error( $result ) ) {
-			return $result;
+			return wp_send_json_error(array(
+				'message' => $result->get_error_message(),
+				'details' => $result->get_error_data(),
+			), $result->get_error_code());
 		}
 		$pdc_order               = $result->order;
 		$pdc_order_item          = $pdc_order->items[0];

--- a/admin/js/pdc-connector-admin.js
+++ b/admin/js/pdc-connector-admin.js
@@ -119,9 +119,8 @@ const PLUGIN_NAME = pdcAdminApi.plugin_name;
         .promise();
       await refreshOrderItem(orderItemId);
     } catch (err) {
-      const message = err?.responseJSON?.message || err?.responseText || 'Something went wrong. Please try again.';
-      console.error('AJAX error:', message);
-      $('#js-pdc-request-response').text(message);
+      const response = err?.responseJSON;
+      $('#js-pdc-request-response').text(response.data?.message);
     } finally {
       loading = false;
       $('#pdc-order').removeClass('button-disabled');

--- a/pdc-connector.php
+++ b/pdc-connector.php
@@ -22,7 +22,7 @@
  *
  * @wordpress-plugin
  * Plugin Name:       Print.com Print on Demand
- * Plugin URI:        https://print.com
+ * Plugin URI:        https://github.com/printdotcom/pdc-connector
  * Description:       Allows customers to configure, edit and purchase products via the Print.com API.
  * Version:           1.0.0
  * Author:            Print.com


### PR DESCRIPTION
This prepares v1.0.0-beta.3.

Changes included:
- fix(admin): standardize JSON error responses and surface meaningful messages
  - Return wp_send_json_error with message, details and status in AdminCore
  - Map API errors to HTTP-like codes and special-case missing preset with env and preset_id
  - Update admin UI to read structured error from response.data.message
  - Update plugin URI to GitHub repository

Once merged, tag: v1.0.0-beta.3