### PR TITLE
chore: release preview fixes for 1.0.0-rc1

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,16 +4,15 @@ package.json
 package-lock.json
 debug.log
 
-# PHP/composer dev
-composer.lock
-# Exclude all of vendor except the autoloader pieces needed at runtime
-vendor/*
-!vendor/
-!vendor/autoload.php
+# composer
+# Due to a bug in gitignore-checker we have to exclude
+# devdependencies manually.
 !vendor/composer/
 !vendor/composer/**
-phpcs.xml.dist
-.phpcs-cache
+vendor/dealerdirect
+vendor/squizlabs
+vendor/phpcsstandards
+vendor/wp-coding-standards
 
 # tests & reports
 test
@@ -22,6 +21,8 @@ phpunit.xml
 phpcs.xml
 playwright-report
 test-results
+phpcs.xml.dist
+.phpcs-cache
 
 # config & scripts
 bin
@@ -35,3 +36,4 @@ bin
 
 # editor/os
 .vscode
+.DS_Store

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -191,27 +191,27 @@ class AdminCore {
 	 * @return void
 	 */
 	public function save_product_data_fields( $post_id ) {
-		if ( empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) {
+		if ( empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( wp_unslash( sanitize_key( $_POST['woocommerce_meta_nonce'] ) ), 'woocommerce_save_data' ) ) {
 			return;
 		}
 
 		$key_product_sku = $this->get_meta_key( 'product_sku' );
 		if ( isset( $_POST[ $key_product_sku ] ) ) {
-			$raw_value = wp_unslash( sanitize_key( $_POST[ $key_product_sku ] ) );
+			$raw_value = sanitize_key( wp_unslash( $_POST[ $key_product_sku ] ) );
 			$sanitized = is_array( $raw_value ) ? array_map( 'sanitize_text_field', $raw_value ) : sanitize_text_field( $raw_value );
 			update_post_meta( $post_id, $key_product_sku, $sanitized );
 		}
 
 		$key_preset_id = $this->get_meta_key( 'preset_id' );
 		if ( isset( $_POST[ $key_preset_id ] ) ) {
-			$raw_value = wp_unslash( sanitize_key( $_POST[ $key_preset_id ] ) );
+			$raw_value = sanitize_key( wp_unslash( $_POST[ $key_preset_id ] ) );
 			$sanitized = is_array( $raw_value ) ? array_map( 'sanitize_text_field', $raw_value ) : sanitize_text_field( $raw_value );
 			update_post_meta( $post_id, $key_preset_id, $sanitized );
 		}
 
 		$key_pdf_url = $this->get_meta_key( 'pdf_url' );
 		if ( isset( $_POST[ $key_pdf_url ] ) ) {
-			$raw_value = wp_unslash( sanitize_url( $_POST[ $key_pdf_url ] ) );
+			$raw_value =  sanitize_url( wp_unslash( $_POST[ $key_pdf_url ] ) );
 			$sanitized = is_array( $raw_value ) ? array_map( 'sanitize_url', $raw_value ) : sanitize_text_field( $raw_value );
 			update_post_meta( $post_id, $key_pdf_url, $sanitized );
 		}

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -211,7 +211,7 @@ class AdminCore {
 
 		$key_pdf_url = $this->get_meta_key( 'pdf_url' );
 		if ( isset( $_POST[ $key_pdf_url ] ) ) {
-			$raw_value =  sanitize_url( wp_unslash( $_POST[ $key_pdf_url ] ) );
+			$raw_value = sanitize_url( wp_unslash( $_POST[ $key_pdf_url ] ) );
 			$sanitized = is_array( $raw_value ) ? array_map( 'sanitize_url', $raw_value ) : sanitize_text_field( $raw_value );
 			update_post_meta( $post_id, $key_pdf_url, $sanitized );
 		}

--- a/admin/partials/pdc-connector-html-order-metabox.php
+++ b/admin/partials/pdc-connector-html-order-metabox.php
@@ -82,13 +82,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<?php
 								if ( empty( $pdc_connector_pdf_url ) ) {
 									?>
-								<a href="#" id="pdc-file-upload" data-order-item-id="<?php echo esc_attr( $pdc_connector_order_item_id ); ?>" class="button button-secondary"><?php esc_html_e( 'Upload PDF', 'pdc-connector' ); ?></a><?php } ?>
+								<button type="button" id="pdc-file-upload" data-order-item-id="<?php echo esc_attr( $pdc_connector_order_item_id ); ?>" class="button button-secondary"><?php esc_html_e( 'Upload PDF', 'pdc-connector' ); ?></button><?php } ?>
 								<?php
 								if ( $pdc_connector_pdf_url ) {
 									?>
-								<a href="#" id="pdc-file-upload" data-order-item-id="<?php echo esc_attr( $pdc_connector_order_item_id ); ?>" class="button button-secondary"><?php esc_html_e( 'Replace PDF', 'pdc-connector' ); ?></a><?php } ?>
+								<button type="button" id="pdc-file-upload" data-order-item-id="<?php echo esc_attr( $pdc_connector_order_item_id ); ?>" class="button button-secondary"><?php esc_html_e( 'Replace PDF', 'pdc-connector' ); ?></button><?php } ?>
 								<?php if ( $pdc_connector_has_preset ) { ?>
-									<a id="pdc-order" data-testid="pdc-purchase-orderitem" data-order-item-id="<?php echo esc_attr( $pdc_connector_order_item_id ); ?>" href="#" class="button button-primary"><?php esc_html_e( 'Purchase', 'pdc-connector' ); ?></a>
+									<button type="button" id="pdc-order" data-testid="pdc-purchase-orderitem" data-order-item-id="<?php echo esc_attr( $pdc_connector_order_item_id ); ?>" class="button button-primary"><?php esc_html_e( 'Purchase', 'pdc-connector' ); ?></button>
 								<?php } ?>
 								<span class="spinner" id="js-pdc-action-spinner"></span>
 								<div class="notice-warning"><span id="js-pdc-request-response"></span></div>


### PR DESCRIPTION
### Changed
- Added .DS_Store to .distignore.
- Explicitly added dev dependencies to .distignore (.gitignore patterns were not applied by dist-archive).
- Sanitized woocommerce_meta_nonce, sku, preset_id, and pdf_url when saving product data.
- Added nonce verification when saving product data.
- Sorted preset titles alphabetically and filtered out products without sku or title.
- Applied filter to product name before purchasing.
- Replaced anchor links with buttons.