### PR TITLE
Release v1.0.0-rc2

### DIFF
--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -618,6 +618,7 @@ class AdminCore {
 		}
 
 		$pdc_connector_presets_for_sku = $response;
+		$pdc_connector_preset_id       = '';
 		ob_start();
 		include plugin_dir_path( __FILE__ ) . 'partials/' . PDC_CONNECTOR_NAME . '-admin-preset-select.php';
 		$preset_select_html = ob_get_contents();
@@ -746,7 +747,9 @@ class AdminCore {
 	 * @return void
 	 */
 	public function save_variation_data_fields( $variation_id, $i ) {
-		if ( isset( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) {
+
+		$nonce = isset( $_POST[PDC_CONNECTOR_NAME . '_variations_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST[PDC_CONNECTOR_NAME . '_variations_nonce'] ) ) : '';
+		if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, PDC_CONNECTOR_NAME . '_save_variations' ) ) {
 			return;
 		}
 

--- a/admin/js/pdc-connector-admin.js
+++ b/admin/js/pdc-connector-admin.js
@@ -213,7 +213,19 @@
 
       const variationPresetInputs = document.querySelectorAll('.pdc_variation_preset_select');
       variationPresetInputs.forEach((selectInput) => {
-        selectInput.innerHTML = presetOptionsHTML;
+        if (!selectInput.value) {
+          selectInput.innerHTML = presetOptionsHTML;
+          return;
+        }
+
+        const options = $.parseHTML(presetOptionsHTML);
+        const optionsWithSelected = options.map((o) => {
+          if (o.value === selectInput.value) {
+            o.setAttribute('selected', true);
+          }
+          return o;
+        });
+        $(selectInput).html(optionsWithSelected);
       });
     } catch (err) {
       console.error('Failed to load presets', err);

--- a/admin/partials/pdc-connector-admin-variation-data.php
+++ b/admin/partials/pdc-connector-admin-variation-data.php
@@ -21,6 +21,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @global WP_Post $post   Global post object.
  */
 $pdc_connector_preset_input_name = $pdc_connector_meta_key_preset_id . '[' . $pdc_connector_index . ']';
+
+wp_nonce_field(
+	PDC_CONNECTOR_NAME . '_save_variations',
+	PDC_CONNECTOR_NAME . '_variations_nonce'
+);	
 ?>
 <?php if ( ! empty( $pdc_connector_sku ) ) { ?>
 	<div class="form-row">

--- a/admin/partials/pdc-connector-admin-variation-data.php
+++ b/admin/partials/pdc-connector-admin-variation-data.php
@@ -19,6 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @global array           variation_data
  * @global int             $index
  * @global WP_Post $post   Global post object.
+ * 
+ * @var $pdc_connector_variation_id int
+ * @var $pdc_connector_index int
+ * @var $pdc_connector_meta_key_preset_id string
  */
 $pdc_connector_preset_input_name = $pdc_connector_meta_key_preset_id . '[' . $pdc_connector_index . ']';
 
@@ -35,7 +39,7 @@ wp_nonce_field(
 				<label><?php esc_html_e( 'Print.com Preset', 'pdc-connector' ); ?></label>
 				<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo esc_attr__( 'Select a preset for this variant. When no preset is selected, it will use the default preset of this product.', 'pdc-connector' ); ?>"></span>
 				<span class="pdc-ac-preset-list">
-					<select data-testid="<?php echo esc_attr( 'variation_preset_' . $pdc_connector_index ); ?>" class="pdc_variation_preset_select" name="<?php echo esc_attr( $pdc_connector_preset_input_name ); ?>" value="<?php echo esc_attr( $pdc_connector_preset_id ); ?>">
+					<select data-testid="<?php echo esc_attr( 'variation_preset_' . $pdc_connector_variation_id ); ?>" class="pdc_variation_preset_select" name="<?php echo esc_attr( $pdc_connector_preset_input_name ); ?>" value="<?php echo esc_attr( $pdc_connector_preset_id ); ?>">
 						<?php include plugin_dir_path( __FILE__ ) . '/' . PDC_CONNECTOR_NAME . '-admin-preset-select.php'; ?>
 					</select>
 				</span>

--- a/admin/partials/pdc-connector-admin-variation-data.php
+++ b/admin/partials/pdc-connector-admin-variation-data.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 $pdc_connector_preset_input_name = $pdc_connector_meta_key_preset_id . '[' . $pdc_connector_index . ']';
 
+
 wp_nonce_field(
 	PDC_CONNECTOR_NAME . '_save_variations',
 	PDC_CONNECTOR_NAME . '_variations_nonce'
@@ -34,7 +35,7 @@ wp_nonce_field(
 				<label><?php esc_html_e( 'Print.com Preset', 'pdc-connector' ); ?></label>
 				<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo esc_attr__( 'Select a preset for this variant. When no preset is selected, it will use the default preset of this product.', 'pdc-connector' ); ?>"></span>
 				<span class="pdc-ac-preset-list">
-					<select class="pdc_variation_preset_select" name="<?php echo esc_attr( $pdc_connector_preset_input_name ); ?>" value="<?php echo esc_attr( $pdc_connector_preset_id ); ?>">
+					<select data-testid="<?php echo esc_attr( 'variation_preset_' . $pdc_connector_index ); ?>" class="pdc_variation_preset_select" name="<?php echo esc_attr( $pdc_connector_preset_input_name ); ?>" value="<?php echo esc_attr( $pdc_connector_preset_id ); ?>">
 						<?php include plugin_dir_path( __FILE__ ) . '/' . PDC_CONNECTOR_NAME . '-admin-preset-select.php'; ?>
 					</select>
 				</span>

--- a/admin/partials/pdc-connector-html-order-metabox.php
+++ b/admin/partials/pdc-connector-html-order-metabox.php
@@ -27,7 +27,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php
 		$pdc_connector_meta_key_pdf_url      = $this->get_meta_key( 'pdf_url' );
 		$pdc_connector_meta_key_preset_id    = $this->get_meta_key( 'preset_id' );
-		$pdc_connector_meta_key_preset_title = $this->get_meta_key( 'preset_title' );
 
 		foreach ( $order->get_items() as $pdc_connector_order_item_product ) {
 			$pdc_connector_order_item_id          = $pdc_connector_order_item_product->get_id();
@@ -39,10 +38,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			$pdc_connector_pdf_url                = wc_get_order_item_meta( $pdc_connector_order_item_id, $this->get_meta_key( 'pdf_url' ), true );
 			$pdc_connector_order_item_status      = wc_get_order_item_meta( $pdc_connector_order_item_id, $this->get_meta_key( 'order_item_status' ), true );
 			$pdc_connector_tnt_url                = wc_get_order_item_meta( $pdc_connector_order_item_id, $this->get_meta_key( 'order_item_tnt_url' ), true );
+			$pdc_connector_preset_id              = wc_get_order_item_meta( $pdc_connector_order_item_id, $this->get_meta_key( 'preset_id' ), true );
 
-			$pdc_connector_product     = wc_get_product( $pdc_connector_order_item_product->get_product_id() );
-			$pdc_connector_preset_id   = $pdc_connector_product->get_meta( $pdc_connector_meta_key_preset_id );
-			$pdc_connector_preset_name = $pdc_connector_product->get_meta( $pdc_connector_meta_key_preset_title );
 
 			$pdc_connector_has_file   = $pdc_connector_pdf_url ? true : false;
 			$pdc_connector_has_preset = $pdc_connector_preset_id ? true : false;

--- a/bin/create-dist
+++ b/bin/create-dist
@@ -51,7 +51,7 @@ mkdir -p "$WP_CLI_PACKAGES_DIR" "$WP_CLI_CACHE_DIR" "$COMPOSER_HOME/cache/vcs"
 chown -R www-data:www-data "$WP_CLI_PACKAGES_DIR" "$WP_CLI_CACHE_DIR" "$COMPOSER_HOME"
 
 # 2) now run the install wp dist-archive cmd
-su -s /bin/sh www-data <<WW
+su -s /bin/sh www-data <<'WW'
 set -eu
 git config --global url.https://github.com/.insteadOf git@github.com:
 
@@ -61,8 +61,15 @@ export COMPOSER_HOME="$COMPOSER_HOME"
 
 wp package install wp-cli/dist-archive-command:v3.0.1
 
-# 3) finally create the archive
-wp dist-archive "/var/www/html/wp-content/plugins/pdc-connector" "/var/www/html/wp-content/plugins/pdc-connector" --format=zip
+# 3) create a temp copy to force filesystem state (avoid git archive)
+TMP_DIR=$(mktemp -d)
+cp -r /var/www/html/wp-content/plugins/pdc-connector "$TMP_DIR/pdc-connector"
+rm -rf "$TMP_DIR/pdc-connector/.git" "$TMP_DIR/pdc-connector/.github"
+
+# 4) create the archive from temp copy, output to plugin dir
+wp dist-archive "$TMP_DIR/pdc-connector" "/var/www/html/wp-content/plugins/pdc-connector" --format=zip
+
+rm -rf "$TMP_DIR"
 SH
 
 echo "✓ Archive created in your plugin directory (host-mapped)."

--- a/bin/seed-woocommerce
+++ b/bin/seed-woocommerce
@@ -104,6 +104,15 @@ EOF
 # Activating Plugins
 execute_wp_cli plugin activate woocommerce pdc-connector
 
+# Clean up existing content
+echo "🧹 Cleaning up existing content..."
+execute_sql "
+DELETE FROM wp_posts WHERE post_type IN ('product', 'product_variation', 'page', 'post');
+DELETE FROM wp_postmeta WHERE post_id NOT IN (SELECT ID FROM wp_posts);
+DELETE FROM wp_term_relationships WHERE object_id NOT IN (SELECT ID FROM wp_posts);
+DELETE t, tt FROM wp_terms t JOIN wp_term_taxonomy tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('product_cat', 'product_tag', 'pa_size');
+"
+
 # Configure WooCommerce settings via SQL
 echo "⚙️ Configuring WooCommerce..."
 execute_sql "
@@ -253,12 +262,77 @@ execute_wp_cli wc payment_gateway update cod --enabled=true --user=1 --settings=
 execute_wp_cli option update woocommerce_default_gateway cod
 
 # Create sample products
-echo "🎨 Creating sample products..."
-create_product_sql "PDC-TSHIRT-001" "Custom T-Shirt - Basic" "29.99" "High-quality custom printed t-shirt. Perfect for personal use or promotional purposes. Available in multiple sizes and colors." "t-shirts"
-create_product_sql "PDC-TSHIRT-002" "Custom T-Shirt - Premium" "39.99" "Premium quality custom printed t-shirt with enhanced fabric and printing. Ideal for professional events and gifts." "t-shirts"
-create_product_sql "PDC-POSTER-001" "Custom Poster - A3" "19.99" "High-resolution custom printed poster in A3 size. Perfect for home decoration, office display, or promotional materials." "posters"
-create_product_sql "PDC-POSTER-002" "Custom Poster - A2" "34.99" "Large format custom printed poster in A2 size. Premium paper quality with vibrant colors for professional displays." "posters"
-create_product_sql "PDC-MUG-001" "Custom Mug - Ceramic" "14.99" "Personalized ceramic mug with your custom design. Dishwasher and microwave safe. Perfect for gifts or promotional items." "print-products"
+echo "🎨 Creating simple product..."
+create_product_sql "PDC-FLYERS-001" "Custom Flyers" "14.99" "Personalized flyers with your custom design." "print-products"
+
+echo "🛍️ Creating variable product: Custom Poster"
+
+# Create Size attribute
+execute_wp_cli wc product_attribute create --name="Size" --slug="size" --type="select" --user=1 --porcelain 2>/dev/null || echo "Attribute exists"
+
+# Create attribute terms
+execute_wp_cli term create pa_size "A2" --slug=a2
+execute_wp_cli term create pa_size "A3" --slug=a3
+
+# Get poster category ID
+POSTER_CAT_ID=$(execute_wp_cli term list product_cat --slug=posters --field=term_id --format=ids)
+
+# Create variable product with WP-CLI
+PRODUCT_ID=$(execute_wp_cli post create --post_type=product --post_title="Custom Poster" --post_content="High-resolution custom printed poster. Available in A2 and A3 sizes." --post_status=publish --porcelain)
+
+# Set product metadata and attributes using SQL
+execute_sql "
+SET @product_id = $PRODUCT_ID;
+SET @poster_cat_id = $POSTER_CAT_ID;
+
+-- Set product meta
+INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES
+(@product_id, '_sku', 'PDC-POSTER'),
+(@product_id, '_stock_status', 'instock'),
+(@product_id, '_manage_stock', 'no'),
+(@product_id, '_product_attributes', 'a:1:{s:7:\"pa_size\";a:6:{s:4:\"name\";s:7:\"pa_size\";s:5:\"value\";s:0:\"\";s:8:\"position\";i:0;s:10:\"is_visible\";i:1;s:12:\"is_variation\";i:1;s:11:\"is_taxonomy\";i:1;}}');
+
+-- Link to variable product type and category
+INSERT INTO wp_term_relationships (object_id, term_taxonomy_id) 
+SELECT @product_id, term_taxonomy_id FROM wp_term_taxonomy WHERE taxonomy='product_type' AND term_id=(SELECT term_id FROM wp_terms WHERE slug='variable');
+
+INSERT INTO wp_term_relationships (object_id, term_taxonomy_id)
+SELECT @product_id, term_taxonomy_id FROM wp_term_taxonomy WHERE taxonomy='product_cat' AND term_id=@poster_cat_id;
+
+-- Link product to attribute terms
+INSERT INTO wp_term_relationships (object_id, term_taxonomy_id)
+SELECT @product_id, term_taxonomy_id FROM wp_term_taxonomy WHERE taxonomy='pa_size';
+
+-- Create A3 variation
+INSERT INTO wp_posts (post_author, post_date, post_date_gmt, post_title, post_status, post_name, post_type, post_parent)
+VALUES (1, NOW(), UTC_TIMESTAMP(), 'Custom Poster - A3', 'publish', CONCAT('product-', @product_id, '-a3'), 'product_variation', @product_id);
+SET @var_a3 = LAST_INSERT_ID();
+
+-- Create A2 variation  
+INSERT INTO wp_posts (post_author, post_date, post_date_gmt, post_title, post_status, post_name, post_type, post_parent)
+VALUES (1, NOW(), UTC_TIMESTAMP(), 'Custom Poster - A2', 'publish', CONCAT('product-', @product_id, '-a2'), 'product_variation', @product_id);
+SET @var_a2 = LAST_INSERT_ID();
+
+-- Set variation metadata
+INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES
+(@var_a3, '_sku', 'PDC-POSTER-A3'),
+(@var_a3, '_price', '19.99'),
+(@var_a3, '_regular_price', '19.99'),
+(@var_a3, '_stock_status', 'instock'),
+(@var_a3, '_manage_stock', 'no'),
+(@var_a3, 'attribute_pa_size', 'a3'),
+(@var_a2, '_sku', 'PDC-POSTER-A2'),
+(@var_a2, '_price', '34.99'),
+(@var_a2, '_regular_price', '34.99'),
+(@var_a2, '_stock_status', 'instock'),
+(@var_a2, '_manage_stock', 'no'),
+(@var_a2, 'attribute_pa_size', 'a2'),
+(@product_id, '_price', '19.99'),
+(@product_id, '_min_variation_price', '19.99'),
+(@product_id, '_max_variation_price', '34.99'),
+(@product_id, '_min_variation_regular_price', '19.99'),
+(@product_id, '_max_variation_regular_price', '34.99');
+"
 
 # Update WooCommerce version and setup completion
 echo "🔄 Finalizing WooCommerce setup..."

--- a/front/FrontCore.php
+++ b/front/FrontCore.php
@@ -154,11 +154,11 @@ class FrontCore {
 				if ( ! empty( $variation_preset_id ) ) {
 					$pdc_preset_id = $variation_preset_id;
 				}
+			}
 
-				if ( empty( $pdc_preset_id ) ) {
-					// Variation did not have a preset ID, so get it from the product.
-					$pdc_preset_id = get_post_meta( $product_id, Core::get_meta_key( 'preset_id' ), true );
-				}
+			// Variation did not have a preset ID, so get it from the product.
+			if ( empty( $pdc_preset_id ) ) {
+				$pdc_preset_id = get_post_meta( $product_id, Core::get_meta_key( 'preset_id' ), true );
 			}
 		}
 

--- a/test/e2e/order.spec.ts
+++ b/test/e2e/order.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { configurePoster, orderPoster, setSettings } from './utils';
+import { configureSimpleProduct, orderProduct, setSettings } from './utils';
 
 test.describe('Order', () => {
   test('will purchase the preset copies amount when use_preset_copies is true', async ({ page }) => {
@@ -9,9 +9,9 @@ test.describe('Order', () => {
       usePresetCopies: true,
     });
 
-    await configurePoster(page);
+    await configureSimpleProduct(page, '14');
 
-    await orderPoster(page);
+    await orderProduct(page, 'custom-flyers');
 
     await page.goto('/wp-admin/edit.php?post_type=shop_order');
 
@@ -22,8 +22,8 @@ test.describe('Order', () => {
     // purchase it
     await page.getByTestId('pdc-purchase-orderitem').click();
 
-    // We have configured a preset with 300 copies (see preset.123poster.json), so should be 300 copies.
-    await expect(page.getByTestId('pdc-ordered-copies')).toHaveText('Copies 300');
+    // We have configured a preset with 300 copies (see preset.flyers_a5.json), so should be 500 copies.
+    await expect(page.getByTestId('pdc-ordered-copies')).toHaveText('Copies 500');
   });
 
   test('will purchase the ordered quantity when use_preset_copies is false', async ({ page }) => {
@@ -33,9 +33,9 @@ test.describe('Order', () => {
       usePresetCopies: false,
     });
 
-    await configurePoster(page);
+    await configureSimpleProduct(page, '14');
 
-    await orderPoster(page);
+    await orderProduct(page, 'custom-flyers');
 
     await page.goto('/wp-admin/edit.php?post_type=shop_order');
 

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -64,12 +64,14 @@ test.describe('product', () => {
     // save
     await page.getByRole('button', { name: 'Update' }).click();
 
+    const apiCallPromise = page.waitForResponse('**/pdc/v1/products/posters/presets', {
+      timeout: 2000,
+    });
+
     // go to variations tab and wait for panel to appear
     await page.locator('a[href="#variable_product_options"]').click();
 
-    await page.waitForResponse(/\/pdc\/v1\/products\/posters\/presets/, {
-      timeout: 1000,
-    });
+    await apiCallPromise;
 
     // open A2
     const tableRow = page

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -1,17 +1,20 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
-import { configurePoster } from './utils';
+import { configureSimpleProduct } from './utils';
 
 test.describe('product', () => {
-  test('can configure a preset for a poster', async ({ page }) => {
-    await configurePoster(page);
+  test('can configure a preset for a simple product', async ({ page }) => {
+    await configureSimpleProduct(page, '14');
     await page.getByRole('link', { name: 'Print.com' }).click();
-    await expect(page.getByTestId('pdc-preset-id')).toHaveValue('123poster');
+    await expect(page.getByTestId('pdc-preset-id')).toHaveValue('flyers_a5');
   });
 
   test('can configure a PDF for a product', async ({ page }) => {
-    await page.goto('/wp-admin/post.php?post=16&action=edit');
+    await page.goto('/wp-admin/post.php?post=14&action=edit');
     await page.getByRole('link', { name: 'Print.com' }).click();
+
+    // select product
+    await page.getByTestId('pdc-product-sku').selectOption('flyers');
 
     await page.getByRole('link', { name: 'Choose file' }).click();
     await page.getByRole('tab', { name: 'Upload files' }).click();
@@ -29,5 +32,34 @@ test.describe('product', () => {
 
     const input = page.getByTestId('pdc-file-upload');
     await expect(input).toHaveValue(/pdc_flyera5/);
+  });
+
+  test('can configure a preset and file for a variable product', async ({ page }) => {
+    await page.goto('/wp-admin/post.php?post=15&action=edit');
+
+    // go to pdc tab
+    await page.getByRole('link', { name: 'Print.com' }).click();
+
+    // select product
+    await page.getByTestId('pdc-product-sku').selectOption('posters');
+
+    // save
+    await page.getByRole('button', { name: 'Update' }).click();
+    
+    // go to variations tab and wait for panel to appear
+    await page.locator('a[href="#variable_product_options"]').click();
+    await page.locator('#variable_product_options').waitFor({ state: 'visible' });
+
+    await expect(page.getByRole('heading', { name: /A2/i })).toBeVisible();
+
+    // open A2
+    await page.getByRole('heading', { name: /A2/i }).click();
+    await page.getByTestId('variation_preset_1').waitFor({ state: 'visible' });
+
+    // select preset
+    await page.getByTestId('variation_preset_1').selectOption('posters_a2');
+
+    // save variation
+    await page.getByRole('button', { name: 'Save changes' }).click();
   });
 });

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -62,16 +62,13 @@ test.describe('product', () => {
     await page.getByTestId('pdc-product-sku').selectOption('posters');
 
     // save
-    await page.getByRole('button', { name: 'Update' }).click();
-
-    const apiCallPromise = page.waitForResponse('**/pdc/v1/products/posters/presets', {
-      timeout: 2000,
-    });
+    await Promise.all([
+      page.waitForResponse(r => r.ok() && r.url().includes('rest_route=/pdc/v1/products/posters/presets')),
+      page.getByRole('button', { name: 'Update' }).click(),
+    ]);
 
     // go to variations tab and wait for panel to appear
     await page.locator('a[href="#variable_product_options"]').click();
-
-    await apiCallPromise;
 
     // open A2
     const tableRow = page

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -1,15 +1,27 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
-import { configureSimpleProduct } from './utils';
+import { configureSimpleProduct, setSettings } from './utils';
 
 test.describe('product', () => {
   test('can configure a preset for a simple product', async ({ page }) => {
+    await setSettings(page, {
+      apikey: 'test_key_12345',
+      env: 'stg',
+      usePresetCopies: false,
+    });
+
     await configureSimpleProduct(page, '14');
     await page.getByRole('link', { name: 'Print.com' }).click();
     await expect(page.getByTestId('pdc-preset-id')).toHaveValue('flyers_a5');
   });
 
   test('can configure a PDF for a product', async ({ page }) => {
+    await setSettings(page, {
+      apikey: 'test_key_12345',
+      env: 'stg',
+      usePresetCopies: false,
+    });
+
     await page.goto('/wp-admin/post.php?post=14&action=edit');
     await page.getByRole('link', { name: 'Print.com' }).click();
 
@@ -35,6 +47,12 @@ test.describe('product', () => {
   });
 
   test('can configure a preset and file for a variable product', async ({ page }) => {
+    await setSettings(page, {
+      apikey: 'test_key_12345',
+      env: 'stg',
+      usePresetCopies: false,
+    });
+
     await page.goto('/wp-admin/post.php?post=15&action=edit');
 
     // go to pdc tab

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -45,19 +45,27 @@ test.describe('product', () => {
 
     // save
     await page.getByRole('button', { name: 'Update' }).click();
-    
+
     // go to variations tab and wait for panel to appear
     await page.locator('a[href="#variable_product_options"]').click();
-    await page.locator('#variable_product_options').waitFor({ state: 'visible' });
 
-    await expect(page.getByRole('heading', { name: /A2/i })).toBeVisible();
+    await page.waitForResponse(/\/pdc\/v1\/products\/posters\/presets/, {
+      timeout: 1000,
+    });
 
     // open A2
-    await page.getByRole('heading', { name: /A2/i }).click();
-    await page.getByTestId('variation_preset_1').waitFor({ state: 'visible' });
+    const tableRow = page
+      .locator('.woocommerce_variation.wc-metabox')
+      .filter({ has: page.locator('a.remove_variation[rel="17"]') })
+      .first();
+
+    await tableRow.locator('a.edit_variation.edit').click();
+    const panel = tableRow.locator('.woocommerce_variable_attributes.wc-metabox-content').first();
+
+    await expect(panel.getByTestId('variation_preset_17')).toBeVisible();
 
     // select preset
-    await page.getByTestId('variation_preset_1').selectOption('posters_a2');
+    await page.getByTestId('variation_preset_17').selectOption('posters_a2');
 
     // save variation
     await page.getByRole('button', { name: 'Save changes' }).click();

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-export async function orderPoster(page) {
-  await page.goto('/?product=custom-poster-a3');
+export async function orderProduct(page, productSlug: string) {
+  await page.goto(`/?product=${productSlug}`);
   await page.getByRole('button', { name: 'Add to cart', exact: true }).click();
   await page.getByRole('link', { name: 'View cart' }).click();
   await page.getByRole('link', { name: 'Proceed to checkout' }).click();
@@ -34,12 +34,12 @@ export async function setSettings(page, settings: Settings) {
   await page.getByRole('button', { name: 'Save Settings' }).click();
 }
 
-export async function configurePoster(page) {
-  await page.goto('/wp-admin/post.php?post=16&action=edit');
+export async function configureSimpleProduct(page, productID: string) {
+  await page.goto(`/wp-admin/post.php?post=${productID}&action=edit`);
   await page.getByRole('link', { name: 'Print.com' }).click();
 
   // select product
-  await page.getByTestId('pdc-product-sku').selectOption('posters');
+  await page.getByTestId('pdc-product-sku').selectOption('flyers');
 
   // loading presets for selected product
   await page.waitForResponse(/\/pdc\/v1\/products/, {
@@ -47,7 +47,7 @@ export async function configurePoster(page) {
   });
 
   // select preset
-  await page.getByTestId('pdc-preset-id').selectOption('123poster');
+  await page.getByTestId('pdc-preset-id').selectOption('flyers_a5');
 
   // pdf file = fixture
   await page.getByRole('link', { name: 'Choose file' }).click();

--- a/test/wiremock/__files/preset.flyers_a5.json
+++ b/test/wiremock/__files/preset.flyers_a5.json
@@ -1,0 +1,9 @@
+{
+  "id": "flyers_a5",
+  "sku": "flyers",
+  "configuration": {
+    "size": "a5",
+    "copies": 500,
+    "variants": []
+  }
+}

--- a/test/wiremock/__files/preset.posters_a2.json
+++ b/test/wiremock/__files/preset.posters_a2.json
@@ -1,8 +1,8 @@
 {
-  "id": "123poster",
+  "id": "posters_a2",
   "sku": "poster",
   "configuration": {
-    "size": "a3",
+    "size": "a2",
     "copies": 300,
     "variants": []
   }

--- a/test/wiremock/__files/presets.json
+++ b/test/wiremock/__files/presets.json
@@ -1,11 +1,25 @@
 {
   "items": [
     {
+      "sku": "flyers",
+      "title": {
+        "en": "A5 Flyers"
+      },
+      "id": "flyers_a5"
+    },
+    {
+      "sku": "posters",
+      "title": {
+        "en": "A2 Posters"
+      },
+      "id": "posters_a2"
+    },
+    {
       "sku": "posters",
       "title": {
         "en": "A3 Posters"
       },
-      "id": "123poster"
+      "id": "posters_a3"
     }
   ]
 }

--- a/test/wiremock/mappings/customerpresets.flyers_a5.get.json
+++ b/test/wiremock/mappings/customerpresets.flyers_a5.get.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/customerpresets/flyers_a5",
+    "headers": {
+      "authorization": {
+        "equalTo": "PrintApiKey test_key_12345"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*"
+    },
+    "bodyFileName": "preset.flyers_a5.json"
+  }
+}

--- a/test/wiremock/mappings/customerpresets.posters_a2.get.json
+++ b/test/wiremock/mappings/customerpresets.posters_a2.get.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/customerpresets/123poster",
+    "urlPath": "/customerpresets/posters_a2",
     "headers": {
       "authorization": {
         "equalTo": "PrintApiKey test_key_12345"
@@ -14,6 +14,6 @@
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*"
     },
-    "bodyFileName": "preset.123poster.json"
+    "bodyFileName": "preset.posters_a2.json"
   }
 }


### PR DESCRIPTION
This PR prepares release candidate v1.0.0-rc2.

Overview
- Focused on variation preset handling and stability improvements.
- Includes updates to filters, preset ID handling, and UI behavior for variation selection.

Changes since v1.0.0-rc1

Features
- resolve issue when creating a dist
- add e2e test for variation configuration
- set preset id on regular products as well
- add nonce for variation
- ensure selected option is maintained when select dropdown is rerendered on variation
- set preset id to empty string otherwise warning for undefined variable
- use preset id from ordered item, not from product
- value in filter should be request body
- change filter name and add arg for order_item_id that is purchased

Chore
- remove admin-ajax url in front-end, no longer used

Compatibility / Breaking changes
- No breaking changes detected in the commits since v1.0.0-rc1.

Testing notes
- Verify variation selection persists across re-renders.
- Confirm preset IDs are set correctly for both variation and regular products.
- Validate that filters receive values from the request body and include the new order_item_id argument where applicable.

Meta
- Compare: https://github.com/printdotcom/pdc-connector/compare/v1.0.0-rc1...variation-data-preset
- Release: v1.0.0-rc2