### PR TITLE
feat: stabilize variation preset handling and e2e coverage

### DIFF
--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -748,7 +748,7 @@ class AdminCore {
 	 */
 	public function save_variation_data_fields( $variation_id, $i ) {
 
-		$nonce = isset( $_POST[PDC_CONNECTOR_NAME . '_variations_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST[PDC_CONNECTOR_NAME . '_variations_nonce'] ) ) : '';
+		$nonce = isset( $_POST[ PDC_CONNECTOR_NAME . '_variations_nonce' ] ) ? sanitize_text_field( wp_unslash( $_POST[ PDC_CONNECTOR_NAME . '_variations_nonce' ] ) ) : '';
 		if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, PDC_CONNECTOR_NAME . '_save_variations' ) ) {
 			return;
 		}

--- a/admin/partials/pdc-connector-admin-variation-data.php
+++ b/admin/partials/pdc-connector-admin-variation-data.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @global array           variation_data
  * @global int             $index
  * @global WP_Post $post   Global post object.
- * 
+ *
  * @var $pdc_connector_variation_id int
  * @var $pdc_connector_index int
  * @var $pdc_connector_meta_key_preset_id string
@@ -30,7 +30,7 @@ $pdc_connector_preset_input_name = $pdc_connector_meta_key_preset_id . '[' . $pd
 wp_nonce_field(
 	PDC_CONNECTOR_NAME . '_save_variations',
 	PDC_CONNECTOR_NAME . '_variations_nonce'
-);	
+);
 ?>
 <?php if ( ! empty( $pdc_connector_sku ) ) { ?>
 	<div class="form-row">

--- a/admin/partials/pdc-connector-html-order-metabox.php
+++ b/admin/partials/pdc-connector-html-order-metabox.php
@@ -40,6 +40,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 			$pdc_connector_tnt_url                = wc_get_order_item_meta( $pdc_connector_order_item_id, $this->get_meta_key( 'order_item_tnt_url' ), true );
 			$pdc_connector_preset_id              = wc_get_order_item_meta( $pdc_connector_order_item_id, $this->get_meta_key( 'preset_id' ), true );
 
+			if ( empty( $pdc_connector_preset_id ) ) {
+				$variation_id = $pdc_connector_order_item_product->get_variation_id();
+				if ( $variation_id ) {
+					$pdc_connector_preset_id = get_post_meta( $variation_id, $pdc_connector_meta_key_preset_id, true );
+				}
+
+				if ( empty( $pdc_connector_preset_id ) ) {
+					$product_id = $pdc_connector_order_item_product->get_product_id();
+					if ( $product_id ) {
+						$pdc_connector_preset_id = get_post_meta( $product_id, $pdc_connector_meta_key_preset_id, true );
+					}
+				}
+			}
 
 			$pdc_connector_has_file   = $pdc_connector_pdf_url ? true : false;
 			$pdc_connector_has_preset = $pdc_connector_preset_id ? true : false;

--- a/admin/partials/pdc-connector-html-order-metabox.php
+++ b/admin/partials/pdc-connector-html-order-metabox.php
@@ -25,8 +25,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="table-body">
 		<?php
-		$pdc_connector_meta_key_pdf_url      = $this->get_meta_key( 'pdf_url' );
-		$pdc_connector_meta_key_preset_id    = $this->get_meta_key( 'preset_id' );
+		$pdc_connector_meta_key_pdf_url   = $this->get_meta_key( 'pdf_url' );
+		$pdc_connector_meta_key_preset_id = $this->get_meta_key( 'preset_id' );
 
 		foreach ( $order->get_items() as $pdc_connector_order_item_product ) {
 			$pdc_connector_order_item_id          = $pdc_connector_order_item_product->get_id();
@@ -41,15 +41,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 			$pdc_connector_preset_id              = wc_get_order_item_meta( $pdc_connector_order_item_id, $this->get_meta_key( 'preset_id' ), true );
 
 			if ( empty( $pdc_connector_preset_id ) ) {
-				$variation_id = $pdc_connector_order_item_product->get_variation_id();
-				if ( $variation_id ) {
-					$pdc_connector_preset_id = get_post_meta( $variation_id, $pdc_connector_meta_key_preset_id, true );
+				$pdc_connector_variation_id = $pdc_connector_order_item_product->get_variation_id();
+				if ( $pdc_connector_variation_id ) {
+					$pdc_connector_preset_id = get_post_meta( $pdc_connector_variation_id, $pdc_connector_meta_key_preset_id, true );
 				}
 
 				if ( empty( $pdc_connector_preset_id ) ) {
-					$product_id = $pdc_connector_order_item_product->get_product_id();
-					if ( $product_id ) {
-						$pdc_connector_preset_id = get_post_meta( $product_id, $pdc_connector_meta_key_preset_id, true );
+					$pdc_connector_product_id = $pdc_connector_order_item_product->get_product_id();
+					if ( $pdc_connector_product_id ) {
+						$pdc_connector_preset_id = get_post_meta( $pdc_connector_product_id, $pdc_connector_meta_key_preset_id, true );
 					}
 				}
 			}

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -62,13 +62,13 @@ test.describe('product', () => {
     await page.getByTestId('pdc-product-sku').selectOption('posters');
 
     // save
+    await page.getByRole('button', { name: 'Update' }).click();
+    
+    // open variations and wait for presets to appear
     await Promise.all([
       page.waitForResponse(r => r.ok() && r.url().includes('rest_route=/pdc/v1/products/posters/presets')),
-      page.getByRole('button', { name: 'Update' }).click(),
+      page.locator('a[href="#variable_product_options"]').click(),
     ]);
-
-    // go to variations tab and wait for panel to appear
-    await page.locator('a[href="#variable_product_options"]').click();
 
     // open A2
     const tableRow = page

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -61,14 +61,13 @@ test.describe('product', () => {
     // select product
     await page.getByTestId('pdc-product-sku').selectOption('posters');
 
-    // save
-    await page.getByRole('button', { name: 'Update' }).click();
-    
-    // open variations and wait for presets to appear
+    // save and wait for presets to appear
     await Promise.all([
-      page.waitForResponse(r => r.ok() && r.url().includes('rest_route=/pdc/v1/products/posters/presets')),
-      page.locator('a[href="#variable_product_options"]').click(),
-    ]);
+      page.getByRole('button', { name: 'Update' }).click(),
+      page.waitForResponse((r) => r.ok() && r.url().includes('rest_route=/pdc/v1/products/posters/presets'))]);
+
+    // open variations and
+    await page.locator('a[href="#variable_product_options"]').click();
 
     // open A2
     const tableRow = page


### PR DESCRIPTION
**Changes**

- When order item has no saved preset_id, use current configured preset_id
- improve stability on e2e test for variation