### PR TITLE
1.0.1 Use release output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        files: ${{ github.workspace }}/pdc-pod.zip
+        files: ${{ steps.deploy.outputs.zip-path }}

--- a/pdc-pod.php
+++ b/pdc-pod.php
@@ -24,7 +24,7 @@
  * Plugin Name:       Print.com Print on Demand
  * Plugin URI:        https://github.com/printdotcom/pdc-pod
  * Description:       Allows customers to configure, edit and purchase products via the Print.com API.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            Print.com
  * Author URI:        https://print.com
  * License:           GPL-2.0+


### PR DESCRIPTION
- Output from deploy is the actual zip that is deployed to wordpress.org
- Update plugin header to 1.0.1