### PR TITLE
sku per variation

### DIFF
--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -43,10 +43,11 @@ class AdminCore {
 	/**
 	 * Initialize the class and set its properties.
 	 *
+	 * @param APIClient $pdc_api_client
 	 * @since    1.0.0
 	 */
-	public function __construct() {
-		$this->pdc_client = new APIClient();
+	public function __construct( $pdc_api_client ) {
+		$this->pdc_client = $pdc_api_client;
 	}
 
 	/**
@@ -758,8 +759,12 @@ class AdminCore {
 
 		$pdc_pod_index = isset( $index ) ? intval( $index ) : 0;
 
-		$pdc_pod_sku       = get_post_meta( $pdc_pod_parent_id, $pdc_pod_meta_key_sku, true );
+		$pdc_pod_parent_sku       = get_post_meta( $pdc_pod_parent_id, $pdc_pod_meta_key_sku, true );
+		$pdc_pod_variantion_sku       = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_sku, true );
+		$pdc_pod_sku = ! empty($pdc_pod_variantion_sku) ? $pdc_pod_variantion_sku : $pdc_pod_parent_sku;
 		$pdc_pod_preset_id = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_preset_id, true );
+
+		$pdc_pod_products = $this->pdc_client->search_products();
 
 		$pdc_pod_presets_for_sku = array();
 		if ( ! empty( $pdc_pod_sku ) ) {
@@ -778,7 +783,6 @@ class AdminCore {
 	 * @return void
 	 */
 	public function save_variation_data_fields( $variation_id, $i ) {
-
 		$nonce = isset( $_POST[ PDC_POD_NAME . '_variations_nonce' . $i ] )
 			? sanitize_text_field( wp_unslash( $_POST[ PDC_POD_NAME . '_variations_nonce' . $i ] ) )
 			: '';
@@ -789,6 +793,7 @@ class AdminCore {
 
 		$fields = array(
 			'pdf_url'   => $this->get_meta_key( 'pdf_url' ),
+			'product_sku'   => $this->get_meta_key( 'product_sku' ),
 			'preset_id' => $this->get_meta_key( 'preset_id' ),
 		);
 

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -759,10 +759,10 @@ class AdminCore {
 
 		$pdc_pod_index = isset( $index ) ? intval( $index ) : 0;
 
-		$pdc_pod_parent_sku       = get_post_meta( $pdc_pod_parent_id, $pdc_pod_meta_key_sku, true );
-		$pdc_pod_variantion_sku       = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_sku, true );
-		$pdc_pod_sku = ! empty($pdc_pod_variantion_sku) ? $pdc_pod_variantion_sku : $pdc_pod_parent_sku;
-		$pdc_pod_preset_id = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_preset_id, true );
+		$pdc_pod_parent_sku     = get_post_meta( $pdc_pod_parent_id, $pdc_pod_meta_key_sku, true );
+		$pdc_pod_variantion_sku = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_sku, true );
+		$pdc_pod_sku            = ! empty( $pdc_pod_variantion_sku ) ? $pdc_pod_variantion_sku : $pdc_pod_parent_sku;
+		$pdc_pod_preset_id      = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_preset_id, true );
 
 		$pdc_pod_products = $this->pdc_client->search_products();
 
@@ -792,9 +792,9 @@ class AdminCore {
 		}
 
 		$fields = array(
-			'pdf_url'   => $this->get_meta_key( 'pdf_url' ),
-			'product_sku'   => $this->get_meta_key( 'product_sku' ),
-			'preset_id' => $this->get_meta_key( 'preset_id' ),
+			'pdf_url'     => $this->get_meta_key( 'pdf_url' ),
+			'product_sku' => $this->get_meta_key( 'product_sku' ),
+			'preset_id'   => $this->get_meta_key( 'preset_id' ),
 		);
 
 		foreach ( $fields as $meta_key ) {

--- a/admin/js/pdc-pod-admin.js
+++ b/admin/js/pdc-pod-admin.js
@@ -189,13 +189,16 @@
 
   // rehook dom elements when variations are loaded
   $(document).on('woocommerce_variations_loaded', function onVariationsLoaded() {
-    loadPresetsForSKU();
+    $('.js-pdc-product-selector').on('change', (e) => loadPresetsForSKU(e.target));
     $('.pdc-pod-js-upload-custom-file-btn').on('click', openMediaDialogFromProduct);
   });
 
-  async function loadPresetsForSKU() {
-    const sku = $('#js-pdc-product-selector').val();
+  async function loadPresetsForSKU(target) {
+    const sku = target.value;
     if (!sku) return;
+
+    const productID = target.dataset.product_id;
+    const presetTargets = document.querySelectorAll(`.js-pdc-preset-list-${productID}`);
     try {
       const response = await fetch(`${PDC_POD_ADMIN.root}pdc/v1/products/${encodeURIComponent(sku)}/presets`, {
         method: 'GET',
@@ -209,13 +212,7 @@
       }
       const presetOptionsHTML = payload?.html || '';
 
-      // set options for main product
-      const presetSelectInput = document.getElementById('js-pdc-preset-list');
-      setSelectedValue(presetSelectInput, presetOptionsHTML);
-
-      // set options for each variation
-      const variationPresetInputs = document.querySelectorAll('.pdc_variation_preset_select');
-      variationPresetInputs.forEach((selectInput) => setSelectedValue(selectInput, presetOptionsHTML));
+      presetTargets.forEach((selectInput) => setSelectedValue(selectInput, presetOptionsHTML));
     } catch (err) {
       console.error('Failed to load presets', err);
     }
@@ -228,7 +225,7 @@
   }
 
   $(document).ready(function () {
-    $('#js-pdc-product-selector').on('change', loadPresetsForSKU);
+    $('#js-pdc-product-selector').on('change', (e) => loadPresetsForSKU(e.target));
     $('#pdc-product-file-upload').on('click', openMediaDialogFromOrder);
     $('.pdc-pod-js-upload-custom-file-btn').on('click', openMediaDialogFromProduct);
   });

--- a/admin/partials/pdc-pod-admin-producttab.php
+++ b/admin/partials/pdc-pod-admin-producttab.php
@@ -32,6 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<select
 				id="js-pdc-product-selector"
 				data-testid="pdc-product-sku"
+				data-product_id="<?php echo $post->ID; ?>"
 				name="<?php echo esc_attr( $this->get_meta_key( 'product_sku' ) ); ?>"
 				value="<?php echo esc_attr( (string) $pdc_pod_sku ); ?>">
 				<option disabled selected value><?php esc_html_e( 'Choose a product', 'pdc-pod' ); ?></option>
@@ -43,7 +44,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<p class="form-field">
 			<label for="pdc-presets-label"><?php esc_html_e( 'Print.com Preset', 'pdc-pod' ); ?></label>
 			<span class="pdc-ac-preset-list">
-				<select id="js-pdc-preset-list" class="pdc_preset_select" name="<?php echo esc_attr( $preset_input_name ); ?>" data-testid="pdc-preset-id"  data-current-value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>" value="<?php echo esc_attr( (string) $pdc_pod_preset_id ); ?>">
+				<select
+					id="js-pdc-preset-list"
+					class="pdc_preset_select js-pdc-preset-list-<?php echo esc_attr( $post->ID ); ?>"
+					name="<?php echo esc_attr( $preset_input_name ); ?>" data-testid="pdc-preset-id"  data-current-value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>" value="<?php echo esc_attr( (string) $pdc_pod_preset_id ); ?>">
 					<?php require plugin_dir_path( __FILE__ ) . '/' . PDC_POD_NAME . '-admin-preset-select.php'; ?>
 				</select>
 			</span>

--- a/admin/partials/pdc-pod-admin-variation-data.php
+++ b/admin/partials/pdc-pod-admin-variation-data.php
@@ -20,56 +20,67 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @global int             $index
  * @global WP_Post $post   Global post object.
  *
+ * @var $pdc_pod_products array
  * @var $pdc_pod_variation_id int
  * @var $pdc_pod_index int
  * @var $pdc_pod_meta_key_preset_id string
  */
 $pdc_pod_preset_input_name = $pdc_pod_meta_key_preset_id . '[' . $pdc_pod_index . ']';
-
+$pdc_pod_sku_input_name = $pdc_pod_meta_key_sku . '[' . $pdc_pod_index . ']';
 
 wp_nonce_field(
 	PDC_POD_NAME . '_save_variations' . $pdc_pod_index,
 	PDC_POD_NAME . '_variations_nonce' . $pdc_pod_index
 );
 ?>
-<?php if ( ! empty( $pdc_pod_sku ) ) { ?>
-	<div class="form-row">
-		<div class="options_group pdc_product_options" id="js-pdc-variant-<?php echo esc_attr( $pdc_pod_variation_id ); ?>">
-			<p class="form-row form-field">
-				<label><?php esc_html_e( 'Print.com Preset', 'pdc-pod' ); ?></label>
-				<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo esc_attr__( 'Select a preset for this variant. When no preset is selected, it will use the default preset of this product.', 'pdc-pod' ); ?>"></span>
-				<span class="pdc-ac-preset-list">
-					<select data-testid="<?php echo esc_attr( 'variation_preset_' . $pdc_pod_variation_id ); ?>" class="pdc_variation_preset_select" name="<?php echo esc_attr( $pdc_pod_preset_input_name ); ?>" data-current-value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>" value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>">
-						<?php include plugin_dir_path( __FILE__ ) . '/' . PDC_POD_NAME . '-admin-preset-select.php'; ?>
-					</select>
-				</span>
-			</p>
+<div class="form-row">
+	<div class="options_group pdc_product_options" id="js-pdc-variant-<?php echo esc_attr( $pdc_pod_variation_id ); ?>">
+		<p class="form-row form-field">
+			<label for="js-pdc-product-selector"><?php esc_html_e( 'Print.com SKU', 'pdc-pod' ); ?></label>
+			<select
+				id="js-pdc-product-selector"
+				data-testid="pdc-product-sku"
+				name="<?php echo esc_attr( $pdc_pod_sku_input_name ); ?>"
+				value="<?php echo esc_attr( (string) $pdc_pod_sku ); ?>">
+				<option disabled selected value><?php esc_html_e( 'Choose a product', 'pdc-pod' ); ?></option>
+				<?php foreach ( $pdc_pod_products as $pdc_pod ) { 
+					$title = isset($pdc_pod->title) ? $pdc_pod->title : '';
+					$sku = isset($pdc_pod->sku) ? $pdc_pod->sku : '';
+					?>
+					<option value="<?php echo esc_attr( $sku ); ?>" <?php selected( $sku, $pdc_pod_sku ); ?>><?php echo esc_attr( $title ); ?></option>
+				<?php } ?>
+			</select>
+		</p>
+		<p class="form-row form-field">
+			<label><?php esc_html_e( 'Print.com Preset', 'pdc-pod' ); ?></label>
+			<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo esc_attr__( 'Select a preset for this variant. When no preset is selected, it will use the default preset of this product.', 'pdc-pod' ); ?>"></span>
+			<span class="pdc-ac-preset-list">
+				<select data-testid="<?php echo esc_attr( 'variation_preset_' . $pdc_pod_variation_id ); ?>" class="pdc_variation_preset_select" name="<?php echo esc_attr( $pdc_pod_preset_input_name ); ?>" data-current-value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>" value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>">
+					<?php include plugin_dir_path( __FILE__ ) . PDC_POD_NAME . '-admin-preset-select.php'; ?>
+				</select>
+			</span>
+		</p>
 
-			<?php
-			$pdc_pod_pdf_url         = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_pdf_url, true );
-			$pdc_pod_button_field_id = PDC_POD_NAME . '_' . $pdc_pod_variation_id . '_upload_id';
-			$pdc_pod_file_field_id   = PDC_POD_NAME . '_' . $pdc_pod_variation_id . '_pdf_url';
-			?>
-			<p class="form-row form-field _pdc_editable_field">
-				<label for="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>"><?php esc_html_e( 'PDF', 'pdc-pod' ); ?></label>
-				<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo esc_attr__( 'Enter a URL or select a file which belongs to this variant. This file will be the design which the customer will order.', 'pdc-pod' ); ?>"></span>
-				<span class="form-flex-box">
-					<input type="text" class="input_text" id="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>" placeholder="<?php esc_attr_e( 'http://', 'pdc-pod' ); ?>" name="<?php echo esc_attr( $pdc_pod_meta_key_pdf_url ); ?>[<?php echo esc_attr( $pdc_pod_index ); ?>]" value="<?php echo esc_attr( $pdc_pod_pdf_url ); ?>" />
-					<a
-						href="#"
-						data-pdc-variation-file-field="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>"
-						data-choose="<?php esc_attr_e( 'Choose file', 'pdc-pod' ); ?>"
-						data-update="<?php esc_attr_e( 'Insert file URL', 'pdc-pod' ); ?>"
-						class="button pdc-pod-js-upload-custom-file-btn"
-						id="<?php echo esc_attr( $pdc_pod_button_field_id ); ?>">
-						<?php echo esc_html__( 'Choose file', 'pdc-pod' ); ?>
-					</a>
-				</span>
-			</p>
-		</div>
+		<?php
+		$pdc_pod_pdf_url         = get_post_meta( $pdc_pod_variation_id, $pdc_pod_meta_key_pdf_url, true );
+		$pdc_pod_button_field_id = PDC_POD_NAME . '_' . $pdc_pod_variation_id . '_upload_id';
+		$pdc_pod_file_field_id   = PDC_POD_NAME . '_' . $pdc_pod_variation_id . '_pdf_url';
+		?>
+		<p class="form-row form-field _pdc_editable_field">
+			<label for="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>"><?php esc_html_e( 'PDF', 'pdc-pod' ); ?></label>
+			<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo esc_attr__( 'Enter a URL or select a file which belongs to this variant. This file will be the design which the customer will order.', 'pdc-pod' ); ?>"></span>
+			<span class="form-flex-box">
+				<input type="text" class="input_text" id="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>" placeholder="<?php esc_attr_e( 'http://', 'pdc-pod' ); ?>" name="<?php echo esc_attr( $pdc_pod_meta_key_pdf_url ); ?>[<?php echo esc_attr( $pdc_pod_index ); ?>]" value="<?php echo esc_attr( $pdc_pod_pdf_url ); ?>" />
+				<a
+					href="#"
+					data-pdc-variation-file-field="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>"
+					data-choose="<?php esc_attr_e( 'Choose file', 'pdc-pod' ); ?>"
+					data-update="<?php esc_attr_e( 'Insert file URL', 'pdc-pod' ); ?>"
+					class="button pdc-pod-js-upload-custom-file-btn"
+					id="<?php echo esc_attr( $pdc_pod_button_field_id ); ?>">
+					<?php echo esc_html__( 'Choose file', 'pdc-pod' ); ?>
+				</a>
+			</span>
+		</p>
 	</div>
-<?php } else { ?>
-	<div>
-		<p><?php esc_html_e( 'Please connect a Print.com product to this WooCommerce product first.', 'pdc-pod' ); ?></p>
-	</div>
-<?php } ?>
+</div>

--- a/admin/partials/pdc-pod-admin-variation-data.php
+++ b/admin/partials/pdc-pod-admin-variation-data.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @var $pdc_pod_meta_key_preset_id string
  */
 $pdc_pod_preset_input_name = $pdc_pod_meta_key_preset_id . '[' . $pdc_pod_index . ']';
-$pdc_pod_sku_input_name = $pdc_pod_meta_key_sku . '[' . $pdc_pod_index . ']';
+$pdc_pod_sku_input_name    = $pdc_pod_meta_key_sku . '[' . $pdc_pod_index . ']';
 
 wp_nonce_field(
 	PDC_POD_NAME . '_save_variations' . $pdc_pod_index,
@@ -36,16 +36,19 @@ wp_nonce_field(
 <div class="form-row">
 	<div class="options_group pdc_product_options" id="js-pdc-variant-<?php echo esc_attr( $pdc_pod_variation_id ); ?>">
 		<p class="form-row form-field">
-			<label for="js-pdc-product-selector"><?php esc_html_e( 'Print.com SKU', 'pdc-pod' ); ?></label>
+			<label for="js-pdc-variant-product-<?php echo esc_attr( $pdc_pod_variation_id ); ?>"><?php esc_html_e( 'Print.com SKU', 'pdc-pod' ); ?></label>
 			<select
-				id="js-pdc-product-selector"
+				class="js-pdc-product-selector"
+				data-product_id="<?php echo $pdc_pod_variation_id; ?>"
+				id="js-pdc-variant-product-<?php echo esc_attr( $pdc_pod_variation_id ); ?>"
 				data-testid="pdc-product-sku"
 				name="<?php echo esc_attr( $pdc_pod_sku_input_name ); ?>"
 				value="<?php echo esc_attr( (string) $pdc_pod_sku ); ?>">
 				<option disabled selected value><?php esc_html_e( 'Choose a product', 'pdc-pod' ); ?></option>
-				<?php foreach ( $pdc_pod_products as $pdc_pod ) { 
-					$title = isset($pdc_pod->title) ? $pdc_pod->title : '';
-					$sku = isset($pdc_pod->sku) ? $pdc_pod->sku : '';
+				<?php
+				foreach ( $pdc_pod_products as $pdc_pod ) {
+					$title = isset( $pdc_pod->title ) ? $pdc_pod->title : '';
+					$sku   = isset( $pdc_pod->sku ) ? $pdc_pod->sku : '';
 					?>
 					<option value="<?php echo esc_attr( $sku ); ?>" <?php selected( $sku, $pdc_pod_sku ); ?>><?php echo esc_attr( $title ); ?></option>
 				<?php } ?>
@@ -55,8 +58,13 @@ wp_nonce_field(
 			<label><?php esc_html_e( 'Print.com Preset', 'pdc-pod' ); ?></label>
 			<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo esc_attr__( 'Select a preset for this variant. When no preset is selected, it will use the default preset of this product.', 'pdc-pod' ); ?>"></span>
 			<span class="pdc-ac-preset-list">
-				<select data-testid="<?php echo esc_attr( 'variation_preset_' . $pdc_pod_variation_id ); ?>" class="pdc_variation_preset_select" name="<?php echo esc_attr( $pdc_pod_preset_input_name ); ?>" data-current-value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>" value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>">
-					<?php include plugin_dir_path( __FILE__ ) . PDC_POD_NAME . '-admin-preset-select.php'; ?>
+				<select
+					data-testid="<?php echo esc_attr( 'variation_preset_' . $pdc_pod_variation_id ); ?>" 
+					class="pdc_variation_preset_select js-pdc-preset-list-<?php echo esc_attr( $pdc_pod_variation_id ); ?>"
+					name="<?php echo esc_attr( $pdc_pod_preset_input_name ); ?>"
+					data-current-value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>"
+					value="<?php echo esc_attr( $pdc_pod_preset_id ); ?>">
+					<?php require plugin_dir_path( __FILE__ ) . PDC_POD_NAME . '-admin-preset-select.php'; ?>
 				</select>
 			</span>
 		</p>

--- a/admin/partials/pdc-pod-admin-variation-data.php
+++ b/admin/partials/pdc-pod-admin-variation-data.php
@@ -41,7 +41,7 @@ wp_nonce_field(
 				class="js-pdc-product-selector"
 				data-product_id="<?php echo $pdc_pod_variation_id; ?>"
 				id="js-pdc-variant-product-<?php echo esc_attr( $pdc_pod_variation_id ); ?>"
-				data-testid="pdc-product-sku"
+				data-testid="<?php echo esc_attr( 'variation_sku_' . $pdc_pod_variation_id ); ?>" 
 				name="<?php echo esc_attr( $pdc_pod_sku_input_name ); ?>"
 				value="<?php echo esc_attr( (string) $pdc_pod_sku ); ?>">
 				<option disabled selected value><?php esc_html_e( 'Choose a product', 'pdc-pod' ); ?></option>

--- a/includes/Core.php
+++ b/includes/Core.php
@@ -12,6 +12,7 @@
 namespace PdcPod\Includes;
 
 use PdcPod\Front\FrontCore;
+use PdcPod\Admin\PrintDotCom\APIClient;
 
 
 /**
@@ -136,7 +137,7 @@ class Core {
 	 */
 	private function define_admin_hooks() {
 
-		$plugin_admin = new \PdcPod\Admin\AdminCore();
+		$plugin_admin = new \PdcPod\Admin\AdminCore( new APIClient() );
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );

--- a/test/e2e/product.spec.ts
+++ b/test/e2e/product.spec.ts
@@ -87,4 +87,36 @@ test.describe('product', () => {
     // save variation
     await page.getByRole('button', { name: 'Save changes' }).click();
   });
+
+  test('can configure a different sku for a variation', async ({ page }) => {
+    await page.goto('/wp-admin/post.php?post=15&action=edit');
+    await page.getByRole('link', { name: 'Print.com' }).click();
+    
+    // set main product to posters
+    await page.getByTestId('pdc-product-sku').selectOption('posters');
+    await page.locator('a[href="#variable_product_options"]').click();
+
+    // open A3
+    const tableRow = page
+      .locator('.woocommerce_variation.wc-metabox')
+      .filter({ has: page.locator('a.remove_variation[rel="16"]') })
+      .first();
+
+    await tableRow.locator('a.edit_variation.edit').click();
+    const panel = tableRow.locator('.woocommerce_variable_attributes.wc-metabox-content').first();
+
+    // sku can be entered
+    await expect(panel.getByTestId('variation_sku_16')).toBeVisible();
+
+    // switching sku should make a request to retrieve new presets
+    await Promise.all([
+      page.getByTestId('variation_sku_16').selectOption('flyers'),
+      page.waitForResponse((r) => r.ok() && r.url().includes('rest_route=/pdc/v1/products/flyers/presets')),
+    ]);
+
+    await page.getByTestId('variation_preset_16').selectOption('flyers_a5');
+
+    // save variation
+    await page.getByRole('button', { name: 'Save changes' }).click();
+  });
 });

--- a/test/unit/admin/PrintDotCom/test-APIClient.php
+++ b/test/unit/admin/PrintDotCom/test-APIClient.php
@@ -28,7 +28,9 @@ class Test_APIClient extends TestCase {
 
     public static function setUpBeforeClass() : void
     {
-        define('PDC_POD_NAME', 'pdc-pod-test');
+		if (!defined('PDC_POD_NAME')) {
+			define('PDC_POD_NAME', 'pdc-pod');
+		}
     }
 
 	/**
@@ -39,7 +41,7 @@ class Test_APIClient extends TestCase {
 	public function test_constructor_sets_base_url_using_env() {
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args'  => ['pdc-pod-test-api_key'],
+            'args'  => ['pdc-pod-api_key'],
             'return' => 'fake-api-key',
         ] );
 
@@ -60,13 +62,13 @@ class Test_APIClient extends TestCase {
 	public function test_constructor_sets_printcom_baseurl_when_env_option_is_prod() {
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args'  => ['pdc-pod-test-env'],
+            'args'  => ['pdc-pod-env'],
             'return' => 'prod',
         ] );
 
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args'  => ['pdc-pod-test-api_key'],
+            'args'  => ['pdc-pod-api_key'],
             'return' => 'fake-api-key',
         ] );
 
@@ -83,12 +85,12 @@ class Test_APIClient extends TestCase {
 	public function test_constructor_sets_printcom_baseurl_when_env_option_is_not_set() {
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args'  => ['pdc-pod-test-env'],
+            'args'  => ['pdc-pod-env'],
         ] );
 
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args'  => ['pdc-pod-test-api_key'],
+            'args'  => ['pdc-pod-api_key'],
             'return' => 'fake-api-key',
         ] );
 

--- a/test/unit/admin/test-AdminCore.php
+++ b/test/unit/admin/test-AdminCore.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Test AdminCore functionality
+ *
+ * Tests for the AdminCore class, specifically focusing on variation data
+ * field rendering and SKU prioritization.
+ *
+ * @package Pdc_Pod
+ * @subpackage Pdc_Pod/tests
+ * @since 1.0.1
+ */
+
+namespace PdcPod\Tests;
+
+use PdcPod\Admin\AdminCore;
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+
+/**
+ * AdminCore test case.
+ *
+ * Tests the AdminCore class
+ *
+ * @since 1.0.1
+ */
+class Test_AdminCore extends TestCase
+{
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('PDC_POD_NAME')) {
+            define('PDC_POD_NAME', 'pdc-pod');
+        }
+    }
+
+    /**
+     * Tests render_variation_data_fields.
+     * SKU can be saved on product level and variation level.
+     * It should prioritize the variation level to retrieve presets.
+     *
+     * @since 1.0.1
+     */
+    function test_uses_variation_sku_when_saved()
+    {
+        $parent_id = 123;
+        $variation_id = 456;
+        $parent_sku = 'parent-sku-123';
+        $variation_sku = 'variation-sku-456';
+        $meta_key_sku = '_pdc-pod_product_sku';
+        $meta_key_preset_id = '_pdc-pod_preset_id';
+
+        // Create a mock WP_Post object.
+        $variation_post = $this->getMockBuilder('WP_Post')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $variation_post->ID = $variation_id;
+        $variation_post->post_parent = $parent_id;
+
+        WP_Mock::userFunction('get_post_meta', array(
+            'times' => 1,
+            'args' => array($parent_id, $meta_key_sku, true),
+            'return' => $parent_sku,
+        ));
+
+        WP_Mock::userFunction('get_post_meta', array(
+            'times' => 1,
+            'args' => array($variation_id, $meta_key_sku, true),
+            'return' => $variation_sku,
+        ));
+
+        WP_Mock::userFunction('get_post_meta', array(
+            'times' => 1,
+            'args' => array($variation_id, $meta_key_preset_id, true),
+            'return' => '',
+        ));
+        
+        $meta_key_pdf_url = '_pdc-pod_pdf_url';
+        WP_Mock::userFunction('get_post_meta', array(
+            'times' => 1,
+            'args' => array($variation_id, $meta_key_pdf_url, true),
+            'return' => '',
+        ));
+        
+        WP_Mock::userFunction('wp_nonce_field', array(
+            'times' => 1,
+        ));
+
+        $admin_dir = dirname(__DIR__, 3) . '/admin/';
+        $partials_dir = $admin_dir . 'partials/';
+        
+        WP_Mock::userFunction('plugin_dir_path')
+            ->times(2)
+            ->andReturn($admin_dir, $partials_dir);
+
+        WP_Mock::userFunction('get_option', array(
+            'return' => 'fake-api-key',
+        ));
+
+        $mock_client = $this->getMockBuilder('PdcPod\\Admin\\PrintDotCom\\APIClient')
+            ->disableOriginalConstructor()
+            ->onlyMethods(array('search_products', 'get_presets'))
+            ->getMock();
+
+        $mock_client->expects($this->once())
+            ->method('search_products')
+            ->willReturn(array());
+
+        // Assert that get_presets is called with the variation SKU, not the parent SKU.
+        $mock_client->expects($this->once())
+            ->method('get_presets')
+            ->with($this->equalTo($variation_sku))
+            ->willReturn(array());
+
+        $admin_core = new AdminCore($mock_client);
+
+        ob_start();
+        $admin_core->render_variation_data_fields(0, array(), $variation_post);
+        ob_end_clean();
+    }
+}


### PR DESCRIPTION
Merchants will now be able to select a different sku for a variation. This allows for more than one sku for a product and so more presets.

- Variation SKU is prefilled with the parent SKU;
- The value is only used to retrieve the right preset;

<img width="931" height="503" alt="Screenshot of variation tab" src="https://github.com/user-attachments/assets/6f5abd53-d653-4a82-a691-3165c05af9e1" />

