### PR TITLE
Purchase all order items in a single batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/e2e/.auth/user.json
 /vendor
 .phpcs-cache
 .phpunit.result.cache
+coverage/

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -690,10 +690,8 @@ class AdminCore {
 		$payload    = $body->payload;
 
 		if ( 'ORDER_STATUS_CHANGED' === $event_type ) {
-			$order_id = $request->get_param( 'order_id' );
-
-			if ( 'ACCEPTEDBYSUPPLIER' === $payload->status ) {
-				$this->on_webhook_in_production( $order_id );
+			if ( isset( $payload->status ) && 'ACCEPTEDBYSUPPLIER' === $payload->status ) {
+				$this->on_webhook_in_production( $payload );
 			}
 		}
 
@@ -706,18 +704,24 @@ class AdminCore {
 	 * Sets an order item to 'production' when the webhook event is received.
 	 *
 	 * @since 1.0.0
-	 * @param string $order_id      The WooCommerce order ID.
-	 * @param string $order_item_id The WooCommerce order item ID.
+	 * @param object $payload	The body of the webhook
 	 * @return void
 	 */
-	private function on_webhook_in_production( $order_id ) {
-		// $order_item = new \WC_Order_Item_Product( $order_item_id );
-		// $order_item->update_meta_data( $this->get_meta_key( 'order_item_status' ), 'production' );
-		// $order_item->save();
+	private function on_webhook_in_production( $payload ) {
+		if (! isset( $payload->order_item_number ) ) {
+			Logger::log('expected order item number in webhook payload', 'error', array( 'payload' => $payload ));
+			return;
+		}
 
-		// haal order op en update iedere item
+		$pdc_order_item_number = $payload->order_item_number;
 
-		$order = wc_get_order( $order_id );
+		$order_item_id = $this->get_order_item_id_by_order_item_number( $pdc_order_item_number );
+
+		$order_item = new \WC_Order_Item_Product( $order_item_id );
+		$order_item->update_meta_data( $this->get_meta_key( 'order_item_status' ), 'production' );
+		$order_item->save();
+
+		$order = $order_item->get_order();
 		$note  = __( 'Item is being produced at Print.com.', 'pdc-pod' );
 		$order->add_order_note( $note );
 		$order->save();

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -546,7 +546,7 @@ class AdminCore {
 			'/order-items/(?P<id>\d+)/purchase',
 			array(
 				'methods'             => 'POST',
-				'callback'            => array( $this, 'pdc_place_order' ),
+				'callback'            => array( $this, 'pdc_place_order_item' ),
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
 				},
@@ -767,7 +767,7 @@ class AdminCore {
 	 * @param \WP_REST_Request $request REST request instance.
 	 * @return \WP_REST_Response|\WP_Error REST response or error.
 	 */
-	public function pdc_place_order( \WP_REST_Request $request ) {
+	public function pdc_place_order_item( \WP_REST_Request $request ) {
 		$order_item_id = absint( $request->get_param( 'id' ) );
 		if ( empty( $order_item_id ) ) {
 			return new \WP_Error(

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -927,7 +927,7 @@ class AdminCore {
 		$order_item_id  = (string) $order_item->get_id();
 		$pdc_order_item = null;
 		foreach ( $pdc_order->items as $item ) {
-			$itemReference = (string) $item->customerReference;
+			$itemReference = isset($item->customerReference) ? $item->customerReference : '';
 			if ( $itemReference === $order_item_id ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$pdc_order_item = $item;
 				break;

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -285,18 +285,18 @@ class AdminCore {
 	}
 
 	public function get_preset_id_by_order_item_id( $pdc_pod_order_item_id ) {
-		$pdc_pod_preset_id              = wc_get_order_item_meta( $pdc_pod_order_item_id, Core::get_meta_key('preset_id' ), true );
+		$pdc_pod_preset_id = wc_get_order_item_meta( $pdc_pod_order_item_id, Core::get_meta_key( 'preset_id' ), true );
 		if ( empty( $pdc_pod_preset_id ) ) {
 			$pdc_pod_order_item_product = new \WC_Order_Item_Product( $pdc_pod_order_item_id );
-			$pdc_pod_variation_id = $pdc_pod_order_item_product->get_variation_id();
+			$pdc_pod_variation_id       = $pdc_pod_order_item_product->get_variation_id();
 			if ( $pdc_pod_variation_id ) {
-				$pdc_pod_preset_id = get_post_meta( $pdc_pod_variation_id, Core::get_meta_key('preset_id' ), true );
+				$pdc_pod_preset_id = get_post_meta( $pdc_pod_variation_id, Core::get_meta_key( 'preset_id' ), true );
 			}
 
 			if ( empty( $pdc_pod_preset_id ) ) {
 				$pdc_pod_product_id = $pdc_pod_order_item_product->get_product_id();
 				if ( $pdc_pod_product_id ) {
-					$pdc_pod_preset_id = get_post_meta( $pdc_pod_product_id, Core::get_meta_key('preset_id' ), true );
+					$pdc_pod_preset_id = get_post_meta( $pdc_pod_product_id, Core::get_meta_key( 'preset_id' ), true );
 				}
 			}
 		}
@@ -554,11 +554,91 @@ class AdminCore {
 		);
 		register_rest_route(
 			'pdc/v1',
-			'/order-items/webhook',
+			'/orders/webhook',
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'pdc_order_webhook' ),
 				'permission_callback' => '__return_true',
+			)
+		);
+		register_rest_route(
+			'pdc/v1',
+			'/orders/(?P<id>\d+)/purchase',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'pdc_purchase_order' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
+	}
+
+	public function pdc_purchase_order( \WP_REST_Request $request ) {
+		$order_id = $request->get_param( 'id' );
+
+		Logger::log(
+			'purchasing order',
+			'debug',
+			array(
+				'order_id' => $order_id,
+			)
+		);
+
+		$order       = wc_get_order( $order_id );
+		$order_items = $order->get_items();
+
+		$purchase_items = array();
+		foreach ( $order_items as $order_item ) {
+			$pdc_pod_preset_id = $this->get_preset_id_by_order_item_id( $order_item->get_ID() );
+			$pdc_pod_pdf_url   = $this->get_pdf_url_by_order_item_id( $order_item->get_ID() );
+			$purchase_date     = wc_get_order_item_meta( $order_item->get_ID(), $this->get_meta_key( 'purchase_date' ), true );
+			if ( ! empty( $pdc_pod_preset_id ) && ! empty( $pdc_pod_pdf_url ) && empty( $purchase_date ) ) {
+				$purchase_items[] = array(
+					'order_item'        => $order_item,
+					'pdc_pod_preset_id' => $pdc_pod_preset_id,
+					'pdc_pod_pdf_url'   => $pdc_pod_pdf_url,
+				);
+			}
+		}
+
+		if ( empty( $purchase_items ) ) {
+			return new \WP_Error(
+				'pdc_no_items_to_purchase',
+				__( 'No valid items found to purchase. Ensure items have both a PDF and a preset assigned.', 'pdc-pod' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$pdc_product_config = get_option( PDC_POD_NAME . '-product' );
+		$result             = $this->pdc_client->purchase_order_items( $order, $purchase_items, $pdc_product_config );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$pdc_order = $result->order;
+		foreach ( $pdc_order->items as $pdc_order_item ) {
+			$order_item_id = (int) $pdc_order_item->customerReference;
+			$order_item    = $order->get_item( $order_item_id );
+
+			if ( $order_item ) {
+				$this->update_order_item( $order_item, $pdc_order );
+			} else {
+				Logger::log( 'unable to update order item after purchase', 'error', array( 'order_item_id' => $order_item_id ) );
+			}
+		}
+
+		$note = sprintf(
+			/* translators: %s: Print.com order number */
+			__( 'Order purchased at Print.com with order number: %s.', 'pdc-pod' ),
+			$pdc_order->orderNumber
+		);
+		$order->add_order_note( $note );
+
+		return rest_ensure_response(
+			array(
+				'order' => $pdc_order,
 			)
 		);
 	}
@@ -591,16 +671,24 @@ class AdminCore {
 	 * @return void
 	 */
 	public function pdc_order_webhook( \WP_REST_Request $request ) {
-		$body       = json_decode( $request->get_body() );
+		$body = json_decode( $request->get_body() );
+
+		Logger::log(
+			'webhook received',
+			'debug',
+			array(
+				'body' => $body,
+			)
+		);
+
 		$event_type = $body->event_type;
 		$payload    = $body->payload;
 
 		if ( 'ORDER_STATUS_CHANGED' === $event_type ) {
-			$order_id      = $request->get_param( 'order_id' );
-			$order_item_id = $request->get_param( 'order_item_id' );
+			$order_id = $request->get_param( 'order_id' );
 
 			if ( 'ACCEPTEDBYSUPPLIER' === $payload->status ) {
-				$this->on_webhook_in_production( $order_id, $order_item_id );
+				$this->on_webhook_in_production( $order_id );
 			}
 		}
 
@@ -617,10 +705,12 @@ class AdminCore {
 	 * @param string $order_item_id The WooCommerce order item ID.
 	 * @return void
 	 */
-	private function on_webhook_in_production( string $order_id, string $order_item_id ) {
-		$order_item = new \WC_Order_Item_Product( $order_item_id );
-		$order_item->update_meta_data( $this->get_meta_key( 'order_item_status' ), 'production' );
-		$order_item->save();
+	private function on_webhook_in_production( $order_id ) {
+		// $order_item = new \WC_Order_Item_Product( $order_item_id );
+		// $order_item->update_meta_data( $this->get_meta_key( 'order_item_status' ), 'production' );
+		// $order_item->save();
+
+		// haal order op en update iedere item
 
 		$order = wc_get_order( $order_id );
 		$note  = __( 'Item is being produced at Print.com.', 'pdc-pod' );
@@ -781,12 +871,17 @@ class AdminCore {
 		$order_id   = wc_get_order_id_by_order_item_id( $order_item_id );
 		$order      = wc_get_order( $order_id );
 
-		$pdc_pod_preset_id  = $this->get_preset_id_by_order_item_id( $order_item_id );
-		$pdc_pod_preset_url = $this->get_pdf_url_by_order_item_id( $order_item_id );
+		$pdc_pod_preset_id = $this->get_preset_id_by_order_item_id( $order_item_id );
+		$pdc_pod_pdf_url   = $this->get_pdf_url_by_order_item_id( $order_item_id );
 
 		$pdc_product_config = get_option( PDC_POD_NAME . '-product' );
+		$item               = array(
+			'order_item'        => $order_item,
+			'pdc_pod_preset_id' => $pdc_pod_preset_id,
+			'pdc_pod_pdf_url'   => $pdc_pod_pdf_url,
+		);
 
-		$result = $this->pdc_client->purchase_order_item( $order, $order_item, $pdc_pod_preset_url, $pdc_pod_preset_id, $pdc_product_config );
+		$result = $this->pdc_client->purchase_order_items( $order, array( $item ), $pdc_product_config );
 		if ( is_wp_error( $result ) ) {
 			$status = absint( $result->get_error_code() );
 			if ( 0 === $status ) {
@@ -803,32 +898,13 @@ class AdminCore {
 				)
 			);
 		}
-		$pdc_order               = $result->order;
-		$pdc_order_item          = $pdc_order->items[0];
-		$pdc_order_item_shipment = $pdc_order_item->shipments[0];
-
-		$order_item->update_meta_data( $this->get_meta_key( 'order' ), $pdc_order );
-		$order_item->update_meta_data( $this->get_meta_key( 'purchase_date' ), gmdate( 'c' ) );
-		// Map external API fields to local snake_case variables for linting compliance.
-		$order_number = $pdc_order->orderNumber; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$grand_total  = $pdc_order->grandTotal; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$order_item->update_meta_data( $this->get_meta_key( 'order_number' ), $order_number );
-		$order_item->update_meta_data( $this->get_meta_key( 'grand_total' ), $grand_total );
-		$order_item->update_meta_data( $this->get_meta_key( 'order_status' ), $pdc_order->status );
-		$order_item->update_meta_data( $this->get_meta_key( 'order_item' ), $pdc_order_item );
-		$order_item->update_meta_data( $this->get_meta_key( 'order_item_shipment' ), $pdc_order_item_shipment );
-		$order_item_number = $pdc_order_item->orderItemNumber; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$order_item_status = $pdc_order_item->status; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$order_item_total  = $pdc_order_item->grandTotal; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$order_item->update_meta_data( $this->get_meta_key( 'order_item_number' ), $order_item_number );
-		$order_item->update_meta_data( $this->get_meta_key( 'order_item_status' ), $order_item_status );
-		$order_item->update_meta_data( $this->get_meta_key( 'order_item_grand_total' ), $order_item_total );
-		$order_item->save();
+		$pdc_order = $result->order;
+		$this->update_order_item( $order_item, $pdc_order );
 
 		$note = sprintf(
 			// translators: placeholder is the order number.
 			__( 'Item purchased at Print.com with order number: %s.', 'pdc-pod' ),
-			$order_number
+			$pdc_order->orderNumber
 		);
 		$order->add_order_note( $note );
 
@@ -837,6 +913,49 @@ class AdminCore {
 				'order' => $pdc_order,
 			)
 		);
+	}
+
+	private function update_order_item( $order_item, $pdc_order ) {
+		$order_item->update_meta_data( $this->get_meta_key( 'order' ), $pdc_order );
+		$order_item->update_meta_data( $this->get_meta_key( 'purchase_date' ), gmdate( 'c' ) );
+		$order_number = $pdc_order->orderNumber; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$grand_total  = $pdc_order->grandTotal; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$order_item->update_meta_data( $this->get_meta_key( 'order_number' ), $order_number );
+		$order_item->update_meta_data( $this->get_meta_key( 'grand_total' ), $grand_total );
+		$order_item->update_meta_data( $this->get_meta_key( 'order_status' ), $pdc_order->status );
+
+		$order_item_id  = (string) $order_item->get_id();
+		$pdc_order_item = null;
+		foreach ( $pdc_order->items as $item ) {
+			$itemReference = (string) $item->customerReference;
+			if ( $itemReference === $order_item_id ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$pdc_order_item = $item;
+				break;
+			}
+		}
+
+		if ( null === $pdc_order_item ) {
+			Logger::log(
+				'unable to update order item',
+				'error',
+				array(
+					'order_item_id' => $order_item_id,
+				)
+			);
+			return;
+		}
+
+		$pdc_order_item_shipment = $pdc_order_item->shipments[0];
+
+		$order_item_number = $pdc_order_item->orderItemNumber; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$order_item_status = $pdc_order_item->status; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$order_item_total  = $pdc_order_item->grandTotal; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$order_item->update_meta_data( $this->get_meta_key( 'order_item_number' ), $order_item_number );
+		$order_item->update_meta_data( $this->get_meta_key( 'order_item_status' ), $order_item_status );
+		$order_item->update_meta_data( $this->get_meta_key( 'order_item_grand_total' ), $order_item_total );
+		$order_item->update_meta_data( $this->get_meta_key( 'order_item' ), $pdc_order_item );
+		$order_item->update_meta_data( $this->get_meta_key( 'order_item_shipment' ), $pdc_order_item_shipment );
+		$order_item->save();
 	}
 
 	/**

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -936,8 +936,8 @@ class AdminCore {
 		$order_item_id  = (string) $order_item->get_id();
 		$pdc_order_item = null;
 		foreach ( $pdc_order->items as $item ) {
-			$itemReference = isset( $item->customerReference ) ? $item->customerReference : '';
-			if ( $itemReference === $order_item_id ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$item_reference = isset( $item->customerReference ) ? $item->customerReference : '';
+			if ( $item_reference === $order_item_id ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$pdc_order_item = $item;
 				break;
 			}

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -927,7 +927,7 @@ class AdminCore {
 		$order_item_id  = (string) $order_item->get_id();
 		$pdc_order_item = null;
 		foreach ( $pdc_order->items as $item ) {
-			$itemReference = isset($item->customerReference) ? $item->customerReference : '';
+			$itemReference = isset( $item->customerReference ) ? $item->customerReference : '';
 			if ( $itemReference === $order_item_id ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$pdc_order_item = $item;
 				break;

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -532,7 +532,7 @@ class AdminCore {
 		);
 		register_rest_route(
 			'pdc/v1',
-			'/orders/(?P<id>\d+)/attach-pdf',
+			'/order-items/(?P<id>\d+)/attach-pdf',
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'pdc_attach_pdf' ),
@@ -543,7 +543,7 @@ class AdminCore {
 		);
 		register_rest_route(
 			'pdc/v1',
-			'/orders/(?P<id>\d+)/purchase',
+			'/order-items/(?P<id>\d+)/purchase',
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'pdc_place_order' ),
@@ -554,7 +554,7 @@ class AdminCore {
 		);
 		register_rest_route(
 			'pdc/v1',
-			'/orders/webhook',
+			'/order-items/webhook',
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'pdc_order_webhook' ),

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -351,7 +351,12 @@ class AdminCore {
 			$pdc_pod_presets_for_sku = $this->pdc_client->get_presets( $pdc_pod_sku );
 		}
 
-		$pdc_products = $this->pdc_client->search_products();
+		$pdc_products = array();
+		$search_response = $this->pdc_client->search_products();
+		if ( ! is_wp_error($search_response)) {
+			$pdc_products = $search_response;
+		}
+
 		include plugin_dir_path( __FILE__ ) . 'partials/' . PDC_POD_NAME . '-admin-producttab.php';
 	}
 
@@ -499,7 +504,7 @@ class AdminCore {
 	public function register_pdc_endpoints() {
 		register_rest_route(
 			'pdc/v1',
-			'/products/(?P<sku>[^/]+)/presets',
+			'/products/(?P<sku> ^/]+)/presets',
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'pdc_render_preset_select' ),
@@ -770,7 +775,7 @@ class AdminCore {
 	 * @param string $tracking_url      Tracking URL provided by Print.com.
 	 * @return void
 	 */
-	private function on_webhook_shipped( string $order_item_number, string $tracking_url ) {
+	private function on_webhook_shipped( $order_item_number, $tracking_url ) {
 		$order_item_id = $this->get_order_item_id_by_order_item_number( $order_item_number );
 		$order_item    = new \WC_Order_Item_Product( $order_item_id );
 		$order_item->update_meta_data( $this->get_meta_key( 'order_item_tnt_url' ), $tracking_url );

--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -504,7 +504,7 @@ class AdminCore {
 	public function register_pdc_endpoints() {
 		register_rest_route(
 			'pdc/v1',
-			'/products/(?P<sku> ^/]+)/presets',
+			'/products/(?P<sku>[^/]+)/presets',
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'pdc_render_preset_select' ),

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -54,6 +54,7 @@ class APIClient {
 			$env                        = get_option( PDC_POD_NAME . '-env' );
 			$this->pdc_pod_api_base_url = ( 'prod' === $env ) ? 'https://api.print.com' : 'https://api.stg.print.com';
 		}
+		
 		if ( getenv( 'PDC_POD_API_KEY' ) ) {
 			$this->pdc_pod_api_key = getenv( 'PDC_POD_API_KEY' );
 		} else {
@@ -149,6 +150,12 @@ class APIClient {
 			$args['headers']['Content-Type'] = 'application/json';
 			$args['body']                    = function_exists( 'wp_json_encode' ) ? wp_json_encode( $data ) : json_encode( $data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 		}
+
+		Logger::log('Print.com API request', 'debug', array(
+			'method' => $method,
+			'url'    => $url,
+			'body'   => isset( $args['body'] ) ? $args['body'] : null,
+		));
 
 		$response = wp_remote_request( $url, array_merge( $args, array( 'method' => $method ) ) );
 		if ( is_wp_error( $response ) ) {
@@ -425,13 +432,12 @@ class APIClient {
 
 		$order_id = $order->get_id();
 
-		// $webhook_url = add_query_arg(
-		// array(
-		// 'order_id'      => $order_id,
-		// ),
-		// rest_url( 'pdc/v1/order-items/webhook' )
-		// );
-		$webhook_url = 'https://webhook.site/b8ca812b-5914-4b78-bce2-87e5c3004af3';
+		$webhook_url = add_query_arg(
+			array(
+				'order_id'      => $order_id,
+			),
+			rest_url( 'pdc/v1/orders/webhook' )
+		);
 
 		$order_request_items = array();
 

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -370,7 +370,7 @@ class APIClient {
 				'order_item_id' => $order_item_id,
 				'order_id'      => $order_id,
 			),
-			rest_url( 'pdc/v1/orders/webhook' )
+			rest_url( 'pdc/v1/order-items/webhook' )
 		);
 
 		$order_request = array(

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -286,37 +286,16 @@ class APIClient {
 	}
 
 	/**
-	 * Purchases an order item through the Print.com API.
+	 * Retrieves a specific preset by its ID from the Print.com API.
 	 *
-	 * This function creates a print order by retrieving preset configuration,
-	 * combining it with WooCommerce order data, and submitting it to Print.com.
-	 * It handles preset retrieval, file URLs, shipping addresses, and quantity
-	 * management based on the provided arguments.
+	 * This method fetches the preset details and cleans up the configuration object
+	 * by removing unnecessary API-specific fields like accessories and delivery promises.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param \WC_Order              $order              The WooCommerce order.
-	 * @param \WC_Order_Item_Product $order_item         The WooCommerce order item.
-	 * @param string                 $pdc_pod_preset_url The PDF URL for the print item.
-	 * @param string                 $pdc_pod_preset_id  The Print.com preset ID.
-	 * @param array                  $args {
-	 *     Optional. Arguments for customizing the purchase behavior.
-	 *
-	 *     @type bool $use_preset_copies Whether to use preset-defined copy count.
-	 *                                   If false, uses order item quantity. Default true.
-	 * }
-	 *
-	 * @return object|\WP_Error Returns the Print.com order response object on success,
-	 *                         or \WP_Error on failure with error details.
-	 *
-	 * @phpcsSuppress WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	 * @param string $pdc_pod_preset_id The unique identifier for the Print.com preset.
+	 * @return array|\WP_Error Array containing 'sku' and 'options' on success, WP_Error on failure.
 	 */
-	public function purchase_order_item( $order, $order_item, $pdc_pod_preset_url, $pdc_pod_preset_id, $args = array() ) {
-		$shipping_address = $order->get_address( 'shipping' );
-
-		if ( empty( $shipping_address ) ) {
-			return new \WP_Error( 400, 'No shipping address found', array( 'order' => $order ) );
-		}
+	private function get_preset_by_id( $pdc_pod_preset_id ) {
 		$result = $this->perform_authenticated_request( 'GET', '/customerpresets/' . rawurlencode( $pdc_pod_preset_id ), null );
 		if ( is_wp_error( $result ) ) {
 			Logger::log(
@@ -349,59 +328,136 @@ class APIClient {
 				)
 			);
 		}
+		$preset        = json_decode( $result );
+		$preset_config = $preset->configuration;
+		unset( $preset_config->_accessories );
+		unset( $preset_config->variants );
+		unset( $preset_config->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-		$preset = json_decode( $result );
+		return array(
+			'sku'     => $preset->sku,
+			'options' => $preset_config,
+		);
+	}
 
-		$item_options = $preset->configuration;
-		if ( empty( $args['use_preset_copies'] ) ) {
-			$item_options->copies = $order_item->get_quantity();
+	/**
+	 * Prepares a single order item for the Print.com API request.
+	 *
+	 * Fetches the preset configuration, merges it with the order item data,
+	 * and formats the shipping address to match the Print.com API structure.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WC_Order_Item_Product $order_item       The WooCommerce order item.
+	 * @param string                 $pdc_pod_preset_id  The Print.com preset ID.
+	 * @param string                 $pdc_pod_pdf_url    The PDF URL for the print item.
+	 * @param array                  $shipping_address   The WooCommerce shipping address array.
+	 * @param array                  $purchase_args      Configuration arguments (e.g., use_preset_copies).
+	 * @return array|\WP_Error Prepared item array or WP_Error on failure.
+	 */
+	private function prepare_order_item( $order_item, $pdc_pod_preset_id, $pdc_pod_pdf_url, $shipping_address, $purchase_args ) {
+		$preset = $this->get_preset_by_id( $pdc_pod_preset_id );
+		if ( is_wp_error( $preset ) ) {
+			return $preset;
 		}
 
-		// Remove unwanted options.
-		unset( $item_options->_accessories );
-		unset( $item_options->variants );
-		unset( $item_options->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( empty( $purchase_args['use_preset_copies'] ) ) {
+			$preset['options']->copies = $order_item->get_quantity();
+		}
 
-		$order_item_id = $order_item->get_id();
-		$order_id      = $order->get_id();
-
-		$webhook_url = add_query_arg(
-			array(
-				'order_item_id' => $order_item_id,
-				'order_id'      => $order_id,
-			),
-			rest_url( 'pdc/v1/order-items/webhook' )
-		);
-
-		$order_request = array(
-			'customerReference' => $order->get_order_number() . '-' . $order_item_id,
-			'webhookUrl'        => esc_url_raw( $webhook_url ),
-			'items'             => array(
+		return array(
+			'sku'               => $preset['sku'],
+			'fileUrl'           => $pdc_pod_pdf_url,
+			'options'           => $preset['options'],
+			'approveDesign'     => true,
+			'customerReference' => $order_item->get_id(),
+			'shipments'         => array(
 				array(
-					'sku'           => $preset->sku,
-					'fileUrl'       => $pdc_pod_preset_url,
-					'options'       => $item_options,
-					'approveDesign' => true,
-					'shipments'     => array(
-						array(
-							'address' => array(
-								'city'        => $shipping_address['city'],
-								'country'     => $shipping_address['country'],
-								'firstName'   => $shipping_address['first_name'],
-								'lastName'    => $shipping_address['last_name'],
-								'companyName' => $shipping_address['company'],
-								'postcode'    => $shipping_address['postcode'],
-								'fullstreet'  => $shipping_address['address_1'],
-								'telephone'   => $shipping_address['phone'],
-							),
-							'copies'  => $item_options->copies,
-						),
+					'address' => array(
+						'city'        => $shipping_address['city'],
+						'country'     => $shipping_address['country'],
+						'firstName'   => $shipping_address['first_name'],
+						'lastName'    => $shipping_address['last_name'],
+						'companyName' => $shipping_address['company'],
+						'postcode'    => $shipping_address['postcode'],
+						'fullstreet'  => $shipping_address['address_1'],
+						'telephone'   => $shipping_address['phone'],
 					),
+					'copies'  => $preset['options']->copies,
 				),
 			),
 		);
+	}
 
-		$order_body = apply_filters( PDC_POD_NAME . '_before_purchase_order_item', $order_request, $order_item_id );
+	/**
+	 * Purchases an order item through the Print.com API.
+	 *
+	 * This function creates a print order by retrieving preset configuration,
+	 * combining it with WooCommerce order data, and submitting it to Print.com.
+	 * It handles preset retrieval, file URLs, shipping addresses, and quantity
+	 * management based on the provided arguments.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WC_Order $order            The WooCommerce order.
+	 * @param array     $items            The items to purchase
+	 *      \WC_Order_Item_Product $order_item         The WooCommerce order item.
+	 *      string                 $pdc_pod_pdf_url The PDF URL for the print item.
+	 *      string                 $pdc_pod_preset_id  The Print.com preset ID.
+	 * @param array     $purchase_args {
+	 *     Optional. Arguments for customizing the purchase behavior.
+	 *
+	 *     @type bool $use_preset_copies Whether to use preset-defined copy count.
+	 *                                   If false, uses order item quantity. Default true.
+	 * }
+	 *
+	 * @return object|\WP_Error Returns the Print.com order response object on success,
+	 *                         or \WP_Error on failure with error details.
+	 *
+	 * @phpcsSuppress WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	 */
+	public function purchase_order_items( $order, $items, $purchase_args = array() ) {
+		$shipping_address = $order->get_address( 'shipping' );
+
+		if ( empty( $shipping_address ) ) {
+			return new \WP_Error( 400, 'No shipping address found', array( 'order' => $order ) );
+		}
+
+		$order_id = $order->get_id();
+
+		// $webhook_url = add_query_arg(
+		// array(
+		// 'order_id'      => $order_id,
+		// ),
+		// rest_url( 'pdc/v1/order-items/webhook' )
+		// );
+		$webhook_url = 'https://webhook.site/b8ca812b-5914-4b78-bce2-87e5c3004af3';
+
+		$order_request_items = array();
+
+		foreach ( $items as $item ) {
+			$prepare_result = $this->prepare_order_item(
+				$item['order_item'],
+				$item['pdc_pod_preset_id'],
+				$item['pdc_pod_pdf_url'],
+				$shipping_address,
+				$purchase_args
+			);
+
+			if ( is_wp_error( $prepare_result ) ) {
+				return new \WP_Error( 500, 'unable to create order item', array( 'item' => $item ) );
+			}
+
+			$order_request_items[] = $prepare_result;
+		}
+
+		$order_request = array(
+			'customerReference' => (string) $order_id,
+			'webhookUrl'        => esc_url_raw( $webhook_url ),
+			'items'             => $order_request_items,
+		);
+
+		$order_body = apply_filters( PDC_POD_NAME . '_before_purchase_order_item', $order_request );
 		$result     = $this->perform_authenticated_request(
 			'POST',
 			'/orders',

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -451,7 +451,7 @@ class APIClient {
 			);
 
 			if ( is_wp_error( $prepare_result ) ) {
-				return new \WP_Error( 500, 'unable to create order item', array( 'item' => $item ) );
+				return $prepare_result;
 			}
 
 			$order_request_items[] = $prepare_result;

--- a/admin/css/pdc-pod-admin.css
+++ b/admin/css/pdc-pod-admin.css
@@ -7,6 +7,7 @@
 .pdc-table .table-foot {
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
 	background: #f8f8f8;
 }
 
@@ -53,4 +54,28 @@
 
 .woocommerce_variation a.button-select-pdf-file {
 	padding: 4px 10px 5px 10px;
+}
+
+.pdc-errormark {
+	background: none;
+	display: flex;
+	align-items: center;
+	visibility: hidden;
+    justify-self: flex-end;
+}
+
+.pdc-errormark .dashicons {
+	color: red;
+	margin-right: 5px;
+}
+.pdc-errormark strong {
+	display: block;
+	color: #3c434a;
+}
+.pdc-errormark span {
+	color: #999;    
+	max-height: 2.2rem;
+    display: block;
+    max-width: 400px;
+    overflow: hidden;
 }

--- a/admin/css/pdc-pod-admin.css
+++ b/admin/css/pdc-pod-admin.css
@@ -1,21 +1,32 @@
-/**
- * All of the CSS for your admin-specific functionality should be
- * included in this file.
- */
-
-.pdc-table {
+.woocommerce_page_wc-orders div.pdc-table {
 	display: grid;
 	grid-template-columns: 1fr;
+	margin-top: 0;
+}
+
+.pdc-table .table-foot {
+	display: flex;
+	justify-content: space-between;
+	background: #f8f8f8;
 }
 
 .pdc-table .table-head {
-	background: var(--wp-admin-theme-color-background-04);
+	background: #f8f8f8;
+	color: #999;
+}
+
+.pdc-table .table-cell-auto {
+	flex: 1;
 }
 
 .pdc-table .table-cell,
 .pdc-table .table-head-col {
 	padding: 16px 8px;
-	border-bottom: 1px solid var(--wp-admin-theme-color-darker-20);
+	border-bottom: 1px solid #dfdfdf;
+}
+
+.pdc-table .table-foot .table-cell {
+	border-bottom: none;
 }
 
 .pdc-table .table-head,
@@ -24,43 +35,20 @@
 	grid-template-columns: 1fr 200px;
 }
 
-.woocommerce_options_panel input.autocomplete__input[type=text],
-.woocommerce_options_panel .pdc_input_pdf[type="text"],
+#pdc_order_meta_box .inside {
+	margin: 0;
+	padding: 0;
+}
+
+.pdc-ta .woocommerce_options_panel .pdc_input_pdf[type="text"],
 .woocommerce_variation .pdc_input_pdf[type="text"] {
 	font-size: 14px;
 	height: initial;
 	width: 80%;
 }
 
-.woocommerce_variation input.autocomplete__input[type=text] {
-	font-size: 14px;
-}
-
-li.autocomplete__option {
-	font-size: 14px;
-}
-
-ul.autocomplete__menu {
-	width: calc(80% - 2px);
-	padding-right: 1px;
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
-	border: 1px solid #c3c4c7;
-	box-shadow: 0.6px 2.1px 1.8px rgba(0, 0, 0, 0.035),
-		5px 17px 14px rgba(0, 0, 0, 0.07);
-	position: absolute;
-	top: 30px;
-	max-height: 270px;
-	z-index: 100;
-}
-
-
 .wp-core-ui a.button-select-pdf-file {
 	margin-left: 5px;
-}
-
-.woocommerce_variation ul.autocomplete__menu {
-	top: 40px;
 }
 
 .woocommerce_variation a.button-select-pdf-file {

--- a/admin/css/pdc-pod-admin.css
+++ b/admin/css/pdc-pod-admin.css
@@ -61,21 +61,23 @@
 	display: flex;
 	align-items: center;
 	visibility: hidden;
-    justify-self: flex-end;
+	justify-self: flex-end;
 }
 
 .pdc-errormark .dashicons {
 	color: red;
 	margin-right: 5px;
 }
+
 .pdc-errormark strong {
 	display: block;
 	color: #3c434a;
 }
+
 .pdc-errormark span {
-	color: #999;    
+	color: #999;
 	max-height: 2.2rem;
-    display: block;
-    max-width: 400px;
-    overflow: hidden;
+	display: block;
+	max-width: 400px;
+	overflow: hidden;
 }

--- a/admin/js/pdc-pod-admin.js
+++ b/admin/js/pdc-pod-admin.js
@@ -242,12 +242,34 @@
     selectInput.value = targetValue.trim();
   }
 
+  async function purchaseAll(e) {
+    e.preventDefault();
+    try {
+      $('#js-pdc-order-fieldset').prop('disabled', true);
+      const orderID = e.target.getAttribute('data-order-id');
+      const response = await fetch(`${PDC_POD_ADMIN.root}pdc/v1/orders/${encodeURIComponent(orderID)}/purchase`, {
+        method: 'POST',
+        headers: {
+          'X-WP-Nonce': PDC_POD_ADMIN.nonce,
+        },
+      });
+      if (!response.ok) {
+        const responseText = await response.text();
+        throw new Error(`failed purchase all order items: ${responseText}`);
+      }
+    } catch {
+    } finally {
+      $('#js-pdc-order-fieldset').prop('disabled', false);
+    }
+  }
+
   $(document).ready(function () {
     $('#js-pdc-product-selector').on('change', (e) => loadPresetsForSKU(e.target));
     $('#pdc-product-file-upload').on('click', openMediaDialogFromOrder);
     $('.pdc-pod-js-upload-custom-file-btn').on('click', openMediaDialogFromProduct);
     $(document).on('click', '.js-pdc-file-upload', orderItemAttachPdf);
     $(document).on('click', '.js-pdc-purchase-orderitem', purchaseOrderItem);
+    $(document).on('click', '#js-pdc-purchase-all', purchaseAll);
     $(`#js-${PLUGIN_NAME}-verify_key`).click(checkCredentials);
     $(`#js-${PLUGIN_NAME}-download-logs`).on('click', downloadLogs);
     observeFormChanges(`#js-${PLUGIN_NAME}-general-form`);

--- a/admin/js/pdc-pod-admin.js
+++ b/admin/js/pdc-pod-admin.js
@@ -245,7 +245,7 @@
     e.preventDefault();
     try {
       $('#js-pdc-order-fieldset').prop('disabled', true);
-      const orderID = e.target.getAttribute('data-order-id');
+      const orderID = e.currentTarget.getAttribute('data-order-id');
       const response = await fetch(`${PDC_POD_ADMIN.root}pdc/v1/orders/${encodeURIComponent(orderID)}/purchase`, {
         method: 'POST',
         headers: {

--- a/admin/js/pdc-pod-admin.js
+++ b/admin/js/pdc-pod-admin.js
@@ -68,7 +68,7 @@
         await $.ajax(
           {
             method: 'POST',
-            url: `${PDC_POD_ADMIN.root}pdc/v1/orders/${orderItemId}/attach-pdf`,
+            url: `${PDC_POD_ADMIN.root}pdc/v1/order-items/${orderItemId}/attach-pdf`,
             beforeSend(xhr) {
               xhr.setRequestHeader('X-WP-Nonce', PDC_POD_ADMIN.nonce);
             },
@@ -101,17 +101,14 @@
 
   // On order item detail page, will purchase
   // the order item with Print.com
-  let loading = false;
   async function purchaseOrderItem(e) {
     e.preventDefault();
-    if (loading) return;
-    loading = true;
-    $(e.currentTarget).addClass('button-disabled');
-    $('#js-pdc-action-spinner').addClass('is-active');
-    $('#js-pdc-request-response').text('');
-    const orderItemId = e.target.getAttribute('data-order-item-id');
+
     try {
-      const response = await fetch(`${PDC_POD_ADMIN.root}pdc/v1/orders/${encodeURIComponent(orderItemId)}/purchase`, {
+      $(e.currentTarget).prop('disabled', true);
+      $('#js-pdc-request-response').text('');
+      const orderItemId = e.target.getAttribute('data-order-item-id');
+      const response = await fetch(`${PDC_POD_ADMIN.root}pdc/v1/order-items/${encodeURIComponent(orderItemId)}/purchase`, {
         method: 'POST',
         headers: {
           'X-WP-Nonce': PDC_POD_ADMIN.nonce,
@@ -126,9 +123,7 @@
     } catch (err) {
       $('#js-pdc-request-response').text(err.message || 'Failed to place order.');
     } finally {
-      loading = false;
-      $(e.currentTarget).removeClass('button-disabled');
-      $('#js-pdc-action-spinner').removeClass('is-active');
+      $(e.currentTarget).prop('disabled', false);
     }
   }
 

--- a/admin/js/pdc-pod-admin.js
+++ b/admin/js/pdc-pod-admin.js
@@ -256,7 +256,7 @@
         const responseText = await response.text();
         throw new Error(responseText);
       }
-      await refreshOrder();
+      refreshOrder();
     } catch ( err )  {
       showError('Failed to purchase all order items', err.message);
     } finally {

--- a/admin/js/pdc-pod-admin.js
+++ b/admin/js/pdc-pod-admin.js
@@ -79,8 +79,7 @@
           },
           {}
         );
-        await refreshOrderItem(orderItemId);
-        $('#js-pdc-order-pdf').val(attachment.url);
+        refreshOrder();
       } catch (err) {
         $('#js-pdc-request-response').text(err.responseJSON.message);
       }
@@ -89,14 +88,8 @@
     frame.open();
   }
 
-  function refreshOrderItem(orderItemId) {
-    const orderItemRow = $(`#pdc_order_item_${orderItemId}`);
-    if (!orderItemRow.length) return;
-    return new Promise((resolve) => {
-      orderItemRow.load(`${document.URL} #pdc_order_item_${orderItemId}_inner`, function () {
-        resolve();
-      });
-    });
+  function refreshOrder() {
+    $("#js-pdc-order-metabox").load(`${document.URL} #js-pdc-order-fieldset`);
   }
 
   // On order item detail page, will purchase
@@ -106,7 +99,7 @@
 
     try {
       $(e.currentTarget).prop('disabled', true);
-      $('#js-pdc-request-response').text('');
+      $('#js-pdc-purchase-error').prop('hidden', true);
       const orderItemId = e.target.getAttribute('data-order-item-id');
       const response = await fetch(`${PDC_POD_ADMIN.root}pdc/v1/order-items/${encodeURIComponent(orderItemId)}/purchase`, {
         method: 'POST',
@@ -119,12 +112,18 @@
         const message = payload?.message || payload?.data?.message || 'Failed to place order.';
         throw new Error(message);
       }
-      await refreshOrderItem(orderItemId);
+      refreshOrder();
     } catch (err) {
-      $('#js-pdc-request-response').text(err.message || 'Failed to place order.');
+      showError('Failed to place order', err.message);
     } finally {
       $(e.currentTarget).prop('disabled', false);
     }
+  }
+
+  function showError(title, descr) {
+    $('#js-pdc-purchase-error').css('visibility', 'visible');
+    $('#js-pdc-purchase-error-title').text(title);
+    $('#js-pdc-purchase-error-descr').text(descr);
   }
 
   async function downloadLogs(e) {
@@ -255,9 +254,11 @@
       });
       if (!response.ok) {
         const responseText = await response.text();
-        throw new Error(`failed purchase all order items: ${responseText}`);
+        throw new Error(responseText);
       }
-    } catch {
+      await refreshOrder();
+    } catch ( err )  {
+      showError('Failed to purchase all order items', err.message);
     } finally {
       $('#js-pdc-order-fieldset').prop('disabled', false);
     }

--- a/admin/partials/pdc-pod-admin-variation-data.php
+++ b/admin/partials/pdc-pod-admin-variation-data.php
@@ -81,6 +81,7 @@ wp_nonce_field(
 				<input type="text" class="input_text" id="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>" placeholder="<?php esc_attr_e( 'http://', 'pdc-pod' ); ?>" name="<?php echo esc_attr( $pdc_pod_meta_key_pdf_url ); ?>[<?php echo esc_attr( $pdc_pod_index ); ?>]" value="<?php echo esc_attr( $pdc_pod_pdf_url ); ?>" />
 				<a
 					href="#"
+					data-testid="<?php echo esc_attr( 'variation_file_' . $pdc_pod_variation_id ); ?>"
 					data-pdc-variation-file-field="<?php echo esc_attr( $pdc_pod_file_field_id ); ?>"
 					data-choose="<?php esc_attr_e( 'Choose file', 'pdc-pod' ); ?>"
 					data-update="<?php esc_attr_e( 'Insert file URL', 'pdc-pod' ); ?>"

--- a/admin/partials/pdc-pod-html-order-metabox.php
+++ b/admin/partials/pdc-pod-html-order-metabox.php
@@ -58,7 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<div class="table-cell">
 							<?php if ( $pdc_pod_order_item_number ) { ?>
 								<span><strong><?php esc_html_e( 'Order item number', 'pdc-pod' ); ?></strong> #<?php echo esc_html( $pdc_pod_order_item_number ); ?></span><br>
-								<span data-testid="pdc-ordered-copies-<?php echo esc_attr($items_count); ?>"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
+								<span data-testid="pdc-ordered-copies-<?php echo esc_attr( $items_count ); ?>"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Purchase Date', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_purchase_date ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Item Status', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item_status ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Price', 'pdc-pod' ); ?></strong> <?php echo wp_kses_post( wc_price( $pdc_pod_order_item_grand_total ) ); ?></span><br>

--- a/admin/partials/pdc-pod-html-order-metabox.php
+++ b/admin/partials/pdc-pod-html-order-metabox.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Admin HTML partial: order metabox
  *
@@ -14,115 +15,151 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<div class="wp-list-table pdc-table widefat fixed striped posts">
-	<fieldset id="js-pdc-order-fieldset"> 
-	<div class="table-head">
-		<div class="table-head-col">
-			<strong><?php esc_html_e( 'Information', 'pdc-pod' ); ?></strong>
+<div class="wp-list-table pdc-table widefat fixed striped posts" id="js-pdc-order-metabox">
+	<fieldset id="js-pdc-order-fieldset">
+		<div class="table-head">
+			<div class="table-head-col">
+				<strong><?php esc_html_e( 'Information', 'pdc-pod' ); ?></strong>
+			</div>
+			<div class="table-head-col">
+				<strong><?php esc_html_e( 'Actions', 'pdc-pod' ); ?></strong>
+			</div>
 		</div>
-		<div class="table-head-col">
-			<strong><?php esc_html_e( 'Actions', 'pdc-pod' ); ?></strong>
-		</div>
-	</div>
-	<div class="table-body">
-		<?php
-		$pdc_pod_meta_key_pdf_url   = $this->get_meta_key( 'pdf_url' );
-		$pdc_pod_meta_key_preset_id = $this->get_meta_key( 'preset_id' );
-		$item_index = 0;
-		foreach ( $order->get_items() as $pdc_pod_order_item_product ) {
-			$item_index++;
-			$pdc_pod_order_item_id          = $pdc_pod_order_item_product->get_id();
-			$pdc_pod_order_item             = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item' ), true );
-			$pdc_pod_order_item_number      = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_number' ), true );
-			$pdc_pod_order_item_grand_total = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_grand_total' ), true );
-			$pdc_pod_purchase_date          = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'purchase_date' ), true );
-			$pdc_pod_image_url              = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'image_url' ), true );
-			$pdc_pod_order_item_status      = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_status' ), true );
-			$pdc_pod_tnt_url                = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_tnt_url' ), true );
-			$pdc_pod_pdf_url                = $this->get_pdf_url_by_order_item_id( $pdc_pod_order_item_id );
-			$pdc_pod_preset_id              = $this->get_preset_id_by_order_item_id( $pdc_pod_order_item_id );
-			
-			$pdc_pod_has_file   = ! empty($pdc_pod_pdf_url);
-			$pdc_pod_has_preset = ! empty($pdc_pod_preset_id);
-			$pdc_pod_filename   = basename( $pdc_pod_pdf_url );
-			$pdc_pod_can_purchase = $pdc_pod_has_file && $pdc_pod_has_preset;
-			?>
-			<div class="table-row" id="pdc_order_item_<?php echo esc_attr( $pdc_pod_order_item_id ); ?>">
-				<div class="table-row-contents" id="pdc_order_item_<?php echo esc_attr( $pdc_pod_order_item_id ); ?>_inner">
-					<div class="table-cell">
-						<?php if ( $pdc_pod_order_item_number ) { ?>
-							<span><strong><?php esc_html_e( 'Order item number', 'pdc-pod' ); ?></strong> #<?php echo esc_html( $pdc_pod_order_item_number ); ?></span><br>
-							<span data-testid="pdc-ordered-copies"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
-							<span><strong><?php esc_html_e( 'Purchase Date', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_purchase_date ); ?></span><br>
-							<span><strong><?php esc_html_e( 'Item Status', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item_status ); ?></span><br>
-							<span><strong><?php esc_html_e( 'Price', 'pdc-pod' ); ?></strong> <?php echo wp_kses_post( wc_price( $pdc_pod_order_item_grand_total ) ); ?></span><br>
-							<span><strong><?php esc_html_e( 'Track & Trace', 'pdc-pod' ); ?></strong> <a href="<?php echo esc_url( $pdc_pod_tnt_url ); ?>"><?php echo esc_html( $pdc_pod_tnt_url ); ?></a></span><br>
-						<?php } ?>
+		<div class="table-body">
+			<?php
+			$pdc_pod_meta_key_pdf_url   = $this->get_meta_key( 'pdf_url' );
+			$pdc_pod_meta_key_preset_id = $this->get_meta_key( 'preset_id' );
+			$items_count                = 0;
+			$items_ready                = 0;
+			foreach ( $order->get_items() as $pdc_pod_order_item_product ) {
+				$pdc_pod_order_item_id          = $pdc_pod_order_item_product->get_id();
+				$pdc_pod_order_item             = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item' ), true );
+				$pdc_pod_order_item_number      = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_number' ), true );
+				$pdc_pod_order_item_grand_total = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_grand_total' ), true );
+				$pdc_pod_purchase_date          = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'purchase_date' ), true );
+				$pdc_pod_image_url              = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'image_url' ), true );
+				$pdc_pod_order_item_status      = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_status' ), true );
+				$pdc_pod_tnt_url                = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item_tnt_url' ), true );
+				$pdc_pod_pdf_url                = $this->get_pdf_url_by_order_item_id( $pdc_pod_order_item_id );
+				$pdc_pod_preset_id              = $this->get_preset_id_by_order_item_id( $pdc_pod_order_item_id );
 
-						<?php if ( $pdc_pod_pdf_url ) { ?>
-							<span><strong><?php esc_html_e( 'File', 'pdc-pod' ); ?></strong> <a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( $pdc_pod_pdf_url ); ?>"><?php echo esc_html( $pdc_pod_filename ); ?></a></span><br>
-						<?php } ?>
+				$pdc_pod_has_file     = ! empty( $pdc_pod_pdf_url );
+				$pdc_pod_has_preset   = ! empty( $pdc_pod_preset_id );
+				$pdc_pod_filename     = basename( $pdc_pod_pdf_url );
+				$pdc_pod_can_purchase = $pdc_pod_has_file && $pdc_pod_has_preset;
 
-						<div class="notifications">
-							<?php
-							if ( ! $pdc_pod_has_file ) {
-								?>
-								<p><?php esc_html_e( 'Missing file. Upload one to purchase.', 'pdc-pod' ); ?></p> <?php } ?>
-							<?php
-							if ( ! $pdc_pod_has_preset ) {
-								?>
-								<p><?php esc_html_e( 'Missing preset. You need a connected preset on the product to purchase.', 'pdc-pod' ); ?></p><?php } ?>
-						</div>
-					</div>
-					<div class="table-cell">
-						<div class="actions">
-							<?php if ( null === $pdc_pod_order_item_number || '' === $pdc_pod_order_item_number ) { ?>
-								<input type="text" class="hidden" id="js-pdc-order-pdf" placeholder="<?php esc_attr_e( 'http://', 'pdc-pod' ); ?>" name="<?php echo esc_attr( $pdc_pod_meta_key_pdf_url ); ?>" value="<?php echo esc_attr( $pdc_pod_pdf_url ); ?>" />
+				++$items_count;
+				if ( $pdc_pod_can_purchase && empty( $pdc_pod_purchase_date ) ) {
+					++$items_ready;
+				}
+				?>
+				<div class="table-row" id="pdc_order_item_<?php echo esc_attr( $pdc_pod_order_item_id ); ?>">
+					<div class="table-row-contents" id="pdc_order_item_<?php echo esc_attr( $pdc_pod_order_item_id ); ?>_inner">
+						<div class="table-cell">
+							<?php if ( $pdc_pod_order_item_number ) { ?>
+								<span><strong><?php esc_html_e( 'Order item number', 'pdc-pod' ); ?></strong> #<?php echo esc_html( $pdc_pod_order_item_number ); ?></span><br>
+								<span data-testid="pdc-ordered-copies"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
+								<span><strong><?php esc_html_e( 'Purchase Date', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_purchase_date ); ?></span><br>
+								<span><strong><?php esc_html_e( 'Item Status', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item_status ); ?></span><br>
+								<span><strong><?php esc_html_e( 'Price', 'pdc-pod' ); ?></strong> <?php echo wp_kses_post( wc_price( $pdc_pod_order_item_grand_total ) ); ?></span><br>
+								<span><strong><?php esc_html_e( 'Track & Trace', 'pdc-pod' ); ?></strong> <a href="<?php echo esc_url( $pdc_pod_tnt_url ); ?>"><?php echo esc_html( $pdc_pod_tnt_url ); ?></a></span><br>
+							<?php } ?>
+
+							<?php if ( $pdc_pod_pdf_url ) { ?>
+								<span><strong><?php esc_html_e( 'File', 'pdc-pod' ); ?></strong> <a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( $pdc_pod_pdf_url ); ?>"><?php echo esc_html( $pdc_pod_filename ); ?></a></span><br>
+							<?php } ?>
+
+							<div class="notifications">
 								<?php
-								if ( empty( $pdc_pod_pdf_url ) ) {
+								if ( ! $pdc_pod_has_file ) {
 									?>
+									<p><?php esc_html_e( 'Missing file. Upload one to purchase.', 'pdc-pod' ); ?></p> <?php } ?>
+								<?php
+								if ( ! $pdc_pod_has_preset ) {
+									?>
+									<p><?php esc_html_e( 'Missing preset. You need a connected preset on the product to purchase.', 'pdc-pod' ); ?></p><?php } ?>
+							</div>
+						</div>
+						<div class="table-cell">
+							<div class="actions">
+								<?php if ( null === $pdc_pod_order_item_number || '' === $pdc_pod_order_item_number ) { ?>
+									<input type="text" class="hidden" id="js-pdc-order-pdf-<?php echo esc_attr( $pdc_pod_order_item_id ); ?>" placeholder="<?php esc_attr_e( 'http://', 'pdc-pod' ); ?>" name="<?php echo esc_attr( $pdc_pod_meta_key_pdf_url ); ?>" value="<?php echo esc_attr( $pdc_pod_pdf_url ); ?>" />
 									<button
 										type="button"
-										id="pdc-file-upload-<?php echo esc_attr($item_index); ?>"
+										id="pdc-file-upload-<?php echo esc_attr( $items_count ); ?>"
 										data-order-item-id="<?php echo esc_attr( $pdc_pod_order_item_id ); ?>"
 										class="button button-secondary js-pdc-file-upload">
-										<?php esc_html_e( 'Upload PDF', 'pdc-pod' ); ?>
+										<?php
+										if ( $pdc_pod_pdf_url ) {
+											esc_html_e( 'Replace PDF', 'pdc-pod' );
+										} else {
+											esc_html_e( 'Upload PDF', 'pdc-pod' );
+										}
+										?>
 									</button>
-								<?php } ?>
 
-								<?php if ( $pdc_pod_pdf_url ) { ?>
-									<button type="button" id="pdc-file-upload" data-order-item-id="<?php echo esc_attr( $pdc_pod_order_item_id ); ?>" class="button button-secondary"><?php esc_html_e( 'Replace PDF', 'pdc-pod' ); ?></button>
-								<?php } ?>
-								<?php if ( $pdc_pod_can_purchase ) { ?>
 									<button
 										type="button"
-										id="pdc-order-<?php echo esc_attr($item_index); ?>"
-										data-testid="pdc-purchase-orderitem-<?php echo esc_attr($item_index); ?>"
+										id="pdc-order-<?php echo esc_attr( $items_count ); ?>"
+										data-testid="pdc-purchase-orderitem-<?php echo esc_attr( $items_count ); ?>"
 										data-order-item-id="<?php echo esc_attr( $pdc_pod_order_item_id ); ?>"
-										class="button button-primary js-pdc-purchase-orderitem">
+										class="button button-primary js-pdc-purchase-orderitem"
+										<?php
+										if ( ! $pdc_pod_can_purchase ) {
+											echo 'disabled';
+										}
+										?>
+										>
 										<?php esc_html_e( 'Purchase', 'pdc-pod' ); ?>
 									</button>
-								<?php } ?>
 
-								<span class="spinner" id="js-pdc-action-spinner"></span>
-								<div class="notice-warning"><span id="js-pdc-request-response"></span></div>
-							<?php } ?>
+									<span class="spinner"></span>
+								<?php } ?>
+							</div>
 						</div>
 					</div>
 				</div>
+				<?php
+
+			}
+			?>
+		</div>
+		<div class="table-foot">
+			<div class="table-cell table-cell-auto">
+				<mark class="pdc-errormark" id="js-pdc-purchase-error">
+					<span class="dashicons dashicons-warning"></span>
+					<div>
+						<strong id="js-pdc-purchase-error-title"></strong>
+						<span id="js-pdc-purchase-error-descr"></span>
+					</div>
+				</mark>
 			</div>
-		<?php 
-			
-		} ?>
-	</div>
-	<div class="table-foot">
-		<div class="table-cell table-cell-auto">
+			<div class="table-cell">
+				<span class="spinner"></span>
+				<button
+					type="submit"
+					class="button button-primary"
+					data-order-id="<?php echo esc_attr( $order->get_id() ); ?>"
+					id="js-pdc-purchase-all"
+					<?php
+					if ( 0 === $items_ready ) {
+						echo 'disabled';
+					}
+					?>
+					>
+					<?php
+					if ( $items_ready > 0 ) {
+						printf(
+							/* translators: %d: number of items ready for purchase */
+							esc_html( _n( 'Purchase %d item', 'Purchase all %d items', $items_ready, 'pdc-pod' ) ),
+							number_format_i18n( $items_ready )
+						);
+					} else {
+						esc_html_e( 'No items to purchase', 'pdc-pod' );
+					}
+					?>
+				</button>
+			</div>
 		</div>
-		<div class="table-cell">
-			<button type="submit" class="button button-primary" id="js-pdc-purchase-all">
-				<?php esc_html_e('Purchase all', 'pdc-pod'); ?>
-			</button>
-		</div>
-	</div>
 	</fieldset>
 </div>

--- a/admin/partials/pdc-pod-html-order-metabox.php
+++ b/admin/partials/pdc-pod-html-order-metabox.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="wp-list-table pdc-table widefat fixed striped posts">
+	<fieldset id="js-pdc-order-fieldset"> 
 	<div class="table-head">
 		<div class="table-head-col">
 			<strong><?php esc_html_e( 'Information', 'pdc-pod' ); ?></strong>
@@ -114,4 +115,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			
 		} ?>
 	</div>
+	<div class="table-foot">
+		<div class="table-cell table-cell-auto">
+		</div>
+		<div class="table-cell">
+			<button type="submit" class="button button-primary" id="js-pdc-purchase-all">
+				<?php esc_html_e('Purchase all', 'pdc-pod'); ?>
+			</button>
+		</div>
+	</div>
+	</fieldset>
 </div>

--- a/admin/partials/pdc-pod-html-order-metabox.php
+++ b/admin/partials/pdc-pod-html-order-metabox.php
@@ -137,7 +137,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<div class="table-cell">
 				<span class="spinner"></span>
 				<button
-					type="submit"
+					type="button"
 					class="button button-primary"
 					data-order-id="<?php echo esc_attr( $order->get_id() ); ?>"
 					data-testid="pdc-pod-purchase-all"

--- a/admin/partials/pdc-pod-html-order-metabox.php
+++ b/admin/partials/pdc-pod-html-order-metabox.php
@@ -58,7 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<div class="table-cell">
 							<?php if ( $pdc_pod_order_item_number ) { ?>
 								<span><strong><?php esc_html_e( 'Order item number', 'pdc-pod' ); ?></strong> #<?php echo esc_html( $pdc_pod_order_item_number ); ?></span><br>
-								<span data-testid="pdc-ordered-copies"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
+								<span data-testid="pdc-ordered-copies-<?php echo esc_attr($items_count); ?>"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Purchase Date', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_purchase_date ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Item Status', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item_status ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Price', 'pdc-pod' ); ?></strong> <?php echo wp_kses_post( wc_price( $pdc_pod_order_item_grand_total ) ); ?></span><br>
@@ -140,6 +140,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					type="submit"
 					class="button button-primary"
 					data-order-id="<?php echo esc_attr( $order->get_id() ); ?>"
+					data-testid="pdc-pod-purchase-all"
 					id="js-pdc-purchase-all"
 					<?php
 					if ( 0 === $items_ready ) {

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,2 +1,2 @@
 #!/bin/bash
-vendor/bin/phpunit $@
+XDEBUG_MODE=coverage vendor/bin/phpunit $@

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
     "name": "@printcom/pdc-pod",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@printcom/pdc-pod",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "devDependencies": {
-                "@playwright/test": "^1.53.0"
+                "@playwright/test": "^1.59.1"
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.54.1",
-            "resolved": "https://npm.ops.print.com/@playwright/test/-/test-1.54.1.tgz",
-            "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+            "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.54.1"
+                "playwright": "1.59.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -29,7 +29,7 @@
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
-            "resolved": "https://npm.ops.print.com/fsevents/-/fsevents-2.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "dev": true,
             "hasInstallScript": true,
@@ -43,13 +43,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.54.1",
-            "resolved": "https://npm.ops.print.com/playwright/-/playwright-1.54.1.tgz",
-            "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+            "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.54.1"
+                "playwright-core": "1.59.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -62,9 +62,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.54.1",
-            "resolved": "https://npm.ops.print.com/playwright-core/-/playwright-core-1.54.1.tgz",
-            "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+            "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
       "test:playwright": "playwright test"
     },
     "devDependencies": {
-      "@playwright/test": "^1.53.0"
+      "@playwright/test": "^1.59.1"
     }
   }

--- a/test/e2e/order.spec.ts
+++ b/test/e2e/order.spec.ts
@@ -36,7 +36,7 @@ test.describe('Order', () => {
     await page.getByTestId('pdc-purchase-orderitem-1').click();
     await presetResponsePromise;
 
-    await expect(page.getByTestId('pdc-ordered-copies')).toHaveText('Copies 500');
+    await expect(page.getByTestId('pdc-ordered-copies-1')).toHaveText('Copies 500');
   });
 
   test('will purchase the ordered quantity when use_preset_copies is false', async ({ page }) => {
@@ -63,7 +63,7 @@ test.describe('Order', () => {
     await page.getByTestId('pdc-purchase-orderitem-1').click();
     await responsePromise;
 
-    await expect(page.getByTestId('pdc-ordered-copies')).toHaveText('Copies 1');
+    await expect(page.getByTestId('pdc-ordered-copies-1')).toHaveText('Copies 1');
   });
 
   test('will purchase multiple order items at once', async ({ page }) => {
@@ -106,11 +106,13 @@ test.describe('Order', () => {
 
     await page.locator('table.wp-list-table tbody tr:first-child a.order-view').click();
 
-    await expect(page.getByTestId('pdc-purchase-orderitem-1')).toBeEnabled();
+    await expect(page.getByTestId('pdc-pod-purchase-all')).toBeEnabled();
+
     const responsePromise = page.waitForResponse('**/purchase');
-    await page.getByTestId('pdc-purchase-orderitem-1').click();
+    await page.getByTestId('pdc-pod-purchase-all').click();
     await responsePromise;
 
-    await expect(page.getByTestId('pdc-ordered-copies')).toHaveText('Copies 1');
+    await expect(page.getByTestId('pdc-ordered-copies-1')).toHaveText('Copies 1');
+    await expect(page.getByTestId('pdc-ordered-copies-2')).toHaveText('Copies 1');
   });
 });

--- a/test/e2e/order.spec.ts
+++ b/test/e2e/order.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { configureSimpleProduct, orderProduct, setSettings } from './utils';
+import { configureSimpleProduct, addToCart, placeOrder, setSettings, configureVariableProduct } from './utils';
 
 test.describe('Order', () => {
   test.afterEach(async ({ page }) => {
@@ -21,7 +21,11 @@ test.describe('Order', () => {
 
     await configureSimpleProduct(page, '14');
 
-    await orderProduct(page, 'custom-flyers');
+    await addToCart(page, {
+      slug: 'custom-flyers',
+    });
+
+    await placeOrder(page);
 
     await page.goto('/wp-admin/edit.php?post_type=shop_order');
 
@@ -44,7 +48,59 @@ test.describe('Order', () => {
 
     await configureSimpleProduct(page, '14');
 
-    await orderProduct(page, 'custom-flyers');
+    await addToCart(page, {
+      slug: 'custom-flyers',
+    });
+
+    await placeOrder(page);
+
+    await page.goto('/wp-admin/edit.php?post_type=shop_order');
+
+    await page.locator('table.wp-list-table tbody tr:first-child a.order-view').click();
+
+    await expect(page.getByTestId('pdc-purchase-orderitem-1')).toBeEnabled();
+    const responsePromise = page.waitForResponse('**/purchase');
+    await page.getByTestId('pdc-purchase-orderitem-1').click();
+    await responsePromise;
+
+    await expect(page.getByTestId('pdc-ordered-copies')).toHaveText('Copies 1');
+  });
+
+  test('will purchase multiple order items at once', async ({ page }) => {
+    await setSettings(page, {
+      apikey: 'test_key_12345',
+      env: 'stg',
+      usePresetCopies: false,
+    });
+
+    await configureSimpleProduct(page, '14');
+    await configureVariableProduct(page, {
+      productID: '15',
+      variations: [
+        {
+          variationID: '17',
+          sku: 'posters',
+          preset: 'posters_a2',
+        },
+        {
+          variationID: '16',
+          sku: 'posters',
+          preset: 'posters_a3',
+        },
+      ],
+    });
+
+    await addToCart(page, {
+      slug: 'custom-flyers',
+    });
+    await addToCart(page, {
+      slug: 'custom-poster',
+      options: {
+        pa_size: 'a2',
+      },
+    });
+
+    await placeOrder(page);
 
     await page.goto('/wp-admin/edit.php?post_type=shop_order');
 

--- a/test/e2e/order.spec.ts
+++ b/test/e2e/order.spec.ts
@@ -4,10 +4,11 @@ import { configureSimpleProduct, addToCart, placeOrder, setSettings, configureVa
 test.describe('Order', () => {
   test.afterEach(async ({ page }) => {
     await page.goto('/wp-admin/edit.php?post_type=shop_order');
+    const actions = page.locator('#bulk-action-selector-top');
     const selectAll = await page.locator('#cb-select-all-1');
-    if (await selectAll.isVisible()) {
+    if (await actions.isVisible() && await selectAll.isVisible()) {
       await selectAll.check();
-      await page.locator('#bulk-action-selector-top').selectOption('trash');
+      await actions.selectOption('trash');
       await page.locator('#doaction').click();
     }
   });

--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -1,13 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { setSettings } from './utils';
 
 test.describe('Settings Page', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/wp-admin/admin.php?page=pdc-pod');
-  });
-  test.afterAll(async ({ browser }) => {
-    const afterAllPage = await browser.newPage();
-    await afterAllPage.goto('/wp-admin/admin.php?page=pdc-pod');
-    await afterAllPage.getByTestId('pdc-pod-apikey').fill('test_key_12345');
   });
 
   test.describe('general settings', () => {
@@ -45,7 +41,6 @@ test.describe('Settings Page', () => {
     });
 
     test('show error when api key is invalid', async ({ page }) => {
-
       // set incorrect key
       await page.getByTestId('pdc-pod-apikey').fill('invalid_key');
 
@@ -60,7 +55,6 @@ test.describe('Settings Page', () => {
     });
 
     test('when environment is set to live, show link to production environment', async ({ page }) => {
-
       // select prod
       await page.getByTestId('pdc-pod-environment').selectOption('prod');
       await page.getByTestId('pdc-pod-apikey').fill('test_key_12345');
@@ -84,35 +78,35 @@ test.describe('Settings Page', () => {
   });
 
   test.describe('product settings', () => {
+    test.afterEach(async ({ page }) => {
+      await setSettings(page, {
+        apikey: 'test_key_12345',
+        env: 'stg',
+        usePresetCopies: true,
+      });
+    });
+
     test('user can check the preset copies checkbox and save it', async ({ page }) => {
-      // Check the checkbox
       await page.getByTestId('pdc-pod-use_preset_copies').check();
 
-      // Verify it's checked
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).toBeChecked();
 
-      // Save settings
       await page.getByRole('button', { name: 'Save Settings' }).click();
 
-      // Reload page to verify persistence
       await page.reload();
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).toBeChecked();
     });
 
     test('user can uncheck the preset copies checkbox and save it', async ({ page }) => {
-      // First, ensure the checkbox is checked
       await page.getByTestId('pdc-pod-use_preset_copies').check();
       await page.getByRole('button', { name: 'Save Settings' }).click();
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).toBeChecked();
 
-      // Now uncheck it
       await page.getByTestId('pdc-pod-use_preset_copies').uncheck();
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).not.toBeChecked();
 
-      // Save settings
       await page.getByRole('button', { name: 'Save Settings' }).click();
 
-      // Reload page to verify persistence
       await page.reload();
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).not.toBeChecked();
     });
@@ -125,34 +119,28 @@ test.describe('Settings Page', () => {
       // Navigate away and back
       await page.goto('/wp-admin/admin.php?page=pdc-pod');
 
-      // Verify checkbox is still checked
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).toBeChecked();
     });
 
     test('both general and product settings can be saved together', async ({ page }) => {
-      // Set general settings
-      await page.getByTestId('pdc-pod-apikey').fill('combined_test_key');
-      await page.getByTestId('pdc-pod-environment').selectOption('stg');
+      await setSettings(page, {
+        apikey: 'combined_test_key',
+        env: 'stg',
+        usePresetCopies: true,
+      });
 
-      // Set product settings
       await page.getByTestId('pdc-pod-use_preset_copies').check();
 
-      // Save all settings
       await page.getByRole('button', { name: 'Save Settings' }).click();
 
-      // Verify both sections are saved correctly
       await expect(page.getByTestId('pdc-pod-apikey')).toHaveValue('combined_test_key');
       await expect(page.getByTestId('pdc-pod-environment')).toHaveValue('stg');
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).toBeChecked();
 
-      // Reload to confirm persistence
       await page.reload();
       await expect(page.getByTestId('pdc-pod-apikey')).toHaveValue('combined_test_key');
       await expect(page.getByTestId('pdc-pod-environment')).toHaveValue('stg');
       await expect(page.getByTestId('pdc-pod-use_preset_copies')).toBeChecked();
-
-      // reset key
-      await page.getByTestId('pdc-pod-apikey').fill('test_key_12345');
     });
   });
 });

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -1,10 +1,22 @@
 import path from 'path';
 
-export async function orderProduct(page, productSlug: string) {
-  await page.goto(`/?product=${productSlug}`);
+interface AddToCartParam {
+  slug: string;
+  options?: {[ key: string ]: string }
+}
+export async function addToCart(page, params: AddToCartParam) {
+  await page.goto(`/?product=${params.slug}`);
+  if (params.options) {
+    for (const [key, value] of Object.entries(params.options)) {
+      await page.locator(`#${key}`).selectOption(value);
+    }
+  }
   await page.getByRole('button', { name: 'Add to cart', exact: true }).click();
-  await page.getByRole('link', { name: 'View cart' }).click();
-  await page.getByRole('link', { name: 'Proceed to checkout' }).click();
+}
+
+export async function placeOrder(page) {
+  // 12 = checkout in seeder
+  await page.goto(`/?page_id=12`);
   await page.locator('#billing_first_name').fill('Test');
   await page.locator('#billing_last_name').fill('User');
   await page.getByRole('textbox', { name: 'Street address' }).fill('Teugseweg 18a');
@@ -57,6 +69,41 @@ export async function configureSimpleProduct(page, productID: string) {
   const fileChooser = await fileChooserPromise;
   await fileChooser.setFiles(path.join(__dirname, `/fixtures/pdc_flyera5.pdf`));
   await page.getByRole('button', { name: 'Select File', exact: true }).click();
+
+  await page.getByRole('button', { name: 'Update' }).click();
+}
+
+interface ConfigureVariableProductParams {
+  productID: string;
+  variations: {
+    variationID: string;
+    sku: string;
+    preset: string;
+  }[]
+}
+export async function configureVariableProduct(page, params: ConfigureVariableProductParams) {
+  await page.goto(`/wp-admin/post.php?post=${params.productID}&action=edit`);
+  await page.getByRole('link', { name: 'Variations' }).click();
+  await page.waitForResponse('**/admin-ajax.php');
+  
+  for (let i = 0; i < params.variations.length; i++) {
+    const variation = params.variations[i];
+    await page.locator(`.woocommerce_variation:has-text('#${variation.variationID}')`).click();
+    await page.getByTestId(`variation_sku_${variation.variationID}`).selectOption(params.variations[i].sku);
+    
+    await page.waitForResponse(/\/pdc\/v1\/products/, {
+      timeout: 1000,
+    });
+
+    await page.getByTestId(`variation_preset_${variation.variationID}`).selectOption(params.variations[i].preset);
+    await page.getByTestId(`variation_file_${variation.variationID}`).click();
+    await page.getByRole('tab', { name: 'Upload files' }).click();
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: 'Select Files' }).click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(path.join(__dirname, `/fixtures/pdc_flyera5.pdf`));
+    await page.getByRole('button', { name: 'Select File', exact: true }).click();
+  }
 
   await page.getByRole('button', { name: 'Update' }).click();
 }

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -1,8 +1,9 @@
+import { expect } from '@playwright/test';
 import path from 'path';
 
 interface AddToCartParam {
   slug: string;
-  options?: {[ key: string ]: string }
+  options?: { [key: string]: string };
 }
 export async function addToCart(page, params: AddToCartParam) {
   await page.goto(`/?product=${params.slug}`);
@@ -11,7 +12,9 @@ export async function addToCart(page, params: AddToCartParam) {
       await page.locator(`#${key}`).selectOption(value);
     }
   }
-  await page.getByRole('button', { name: 'Add to cart', exact: true }).click();
+  const addToCartButton = page.getByRole('button', { name: 'Add to cart', exact: true });
+  await expect(addToCartButton).not.toHaveClass(/disabled/);
+  await addToCartButton.click();
 }
 
 export async function placeOrder(page) {
@@ -79,18 +82,18 @@ interface ConfigureVariableProductParams {
     variationID: string;
     sku: string;
     preset: string;
-  }[]
+  }[];
 }
 export async function configureVariableProduct(page, params: ConfigureVariableProductParams) {
   await page.goto(`/wp-admin/post.php?post=${params.productID}&action=edit`);
   await page.getByRole('link', { name: 'Variations' }).click();
   await page.waitForResponse('**/admin-ajax.php');
-  
+
   for (let i = 0; i < params.variations.length; i++) {
     const variation = params.variations[i];
     await page.locator(`.woocommerce_variation:has-text('#${variation.variationID}')`).click();
     await page.getByTestId(`variation_sku_${variation.variationID}`).selectOption(params.variations[i].sku);
-    
+
     await page.waitForResponse(/\/pdc\/v1\/products/, {
       timeout: 1000,
     });

--- a/test/wiremock/__files/order.60001234.json
+++ b/test/wiremock/__files/order.60001234.json
@@ -8,6 +8,7 @@
         "orderItemNumber": "60001234-1",
         "status": "ORDERRECEIVED",
         "grandTotal": 150,
+        "customerReference": "{{jsonPath request.body '$.items[0].customerReference'}}",
         "options": {
           "size": "a3",
           "copies": "{{jsonPath request.body '$.items[0].options.copies'}}"

--- a/test/wiremock/__files/order.60001235.json
+++ b/test/wiremock/__files/order.60001235.json
@@ -1,0 +1,41 @@
+{
+  "order": {
+    "orderNumber": "60001235",
+    "grandTotal": 300,
+    "status": "ORDERRECEIVED",
+    "items": [
+      {
+        "orderItemNumber": "60001235-1",
+        "status": "ORDERRECEIVED",
+        "grandTotal": 50,
+        "customerReference": "{{jsonPath request.body '$.items[0].customerReference'}}",
+        "options": {
+          "size": "a3",
+          "copies": "{{jsonPath request.body '$.items[0].options.copies'}}"
+        },
+        "shipments": [
+          {
+            "deliveryDate": "2025-07-29T19:00.000Z",
+            "method": "PNL"
+          }
+        ]
+      },
+      {
+        "orderItemNumber": "60001235-2",
+        "status": "ORDERRECEIVED",
+        "grandTotal": 100,
+        "customerReference": "{{jsonPath request.body '$.items[1].customerReference'}}",
+        "options": {
+          "size": "a3",
+          "copies": "{{jsonPath request.body '$.items[1].options.copies'}}"
+        },
+        "shipments": [
+          {
+            "deliveryDate": "2025-07-29T19:00.000Z",
+            "method": "PNL"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/wiremock/mappings/orders.post.two-items.json
+++ b/test/wiremock/mappings/orders.post.two-items.json
@@ -1,0 +1,39 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "POST",
+    "urlPath": "/orders",
+    "headers": {
+      "authorization": {
+        "equalTo": "PrintApiKey test_key_12345"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": "$.items[1]"
+      }
+    ]
+  },
+  "response": {
+    "transformers": ["response-template"],
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*"
+    },
+    "bodyFileName": "order.60001235.json"
+  },
+  "serveEventListeners": [
+    {
+      "name": "webhook",
+      "parameters": {
+        "method": "POST",
+        "url": "{{jsonPath originalRequest.body '$.webhookUrl'}}",
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": "{ \"result\": \"SUCCESS\" }"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Adds the ability to purchase all ready order items in a single batch from the WooCommerce order metabox. Previously, items could only be purchased one at a time. This change introduces a "Purchase All" button that sends all eligible items in one API call to the Print.com `/orders` endpoint. The REST route for single-item operations was also renamed from `/orders/` to `/order-items/` for clarity.

## Screenshots

## Commits
123bc00 add xdebug mode to suppress warnings
c8b0e35 format and ignore coverage
71c2872 e2e test for batch order
fbbb329 purchase multiple items
afc5664 add button for purchasing all
527bdd5 hook up purchase all
584c848 change func sig to order item
e27c49e change items endpoint to order-items
f3953c9 add testid for variation
0c134f4 prepare e2e test
37ab54c improve table styling
e377797 update registery and playwright