### PR TITLE
Support WordPress 7.0

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         include:
           - { wp: 60, php: 74 }
-          - { wp: 68, php: 82 }
           - { wp: 69, php: 83 }
+          - { wp: 70, php: 84 }
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         include:
           - { wp: 60, php: 74 }
-          - { wp: 69, php: 83 }
           - { wp: 70, php: 84 }
     steps:
       - name: Checkout code

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: printdotcom
 Donate link: https://print.com
 Tags: woocommerce
 Requires at least: 3.4
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bin/run-wordpress
+++ b/bin/run-wordpress
@@ -94,9 +94,6 @@ else
 fi
 EOF
 
-echo "Activating plug-in.."
-docker compose -f config/docker-compose.yml run --rm wpcli wp plugin activate pdc-pod --allow-root
-
 if [ "$WORDPRESS_VERSION_ENV" -ge 55 ] && [ -n "$PLUGINS_LIST" ]; then
   echo "Installing compatible plugins for WordPress ${WORDPRESS_PORT}.."
   
@@ -110,6 +107,9 @@ if [ "$WORDPRESS_VERSION_ENV" -ge 55 ] && [ -n "$PLUGINS_LIST" ]; then
     docker compose -f config/docker-compose.yml run --rm --user 33 wpcli wp plugin install "$plugin_name" --version="$plugin_version" --activate --allow-root || exit 1
   done
 fi
+
+echo "Activating plug-in.."
+docker compose -f config/docker-compose.yml run --rm wpcli wp plugin activate pdc-pod --allow-root
 
 MAX_ATTEMPTS=10
 ATTEMPT=0

--- a/bin/seed-woocommerce
+++ b/bin/seed-woocommerce
@@ -129,7 +129,9 @@ INSERT INTO wp_options (option_name, option_value, autoload) VALUES
 ('woocommerce_enable_signup_and_login_from_checkout', 'yes', 'yes'),
 ('woocommerce_enable_myaccount_registration', 'yes', 'yes'),
 ('woocommerce_registration_generate_username', 'yes', 'yes'),
-('woocommerce_registration_generate_password', 'yes', 'yes')
+('woocommerce_registration_generate_password', 'yes', 'yes'),
+('woocommerce_feature_site_visibility_badge_enabled', 'no', 'on')
+('woocommerce_coming_soon', 'no', 'auto')
 ON DUPLICATE KEY UPDATE option_value = VALUES(option_value);"
 
 # Create WooCommerce pages

--- a/bin/seed-woocommerce
+++ b/bin/seed-woocommerce
@@ -130,7 +130,7 @@ INSERT INTO wp_options (option_name, option_value, autoload) VALUES
 ('woocommerce_enable_myaccount_registration', 'yes', 'yes'),
 ('woocommerce_registration_generate_username', 'yes', 'yes'),
 ('woocommerce_registration_generate_password', 'yes', 'yes'),
-('woocommerce_feature_site_visibility_badge_enabled', 'no', 'on')
+('woocommerce_feature_site_visibility_badge_enabled', 'no', 'on'),
 ('woocommerce_coming_soon', 'no', 'auto')
 ON DUPLICATE KEY UPDATE option_value = VALUES(option_value);"
 

--- a/config/wp-plugins.conf
+++ b/config/wp-plugins.conf
@@ -1,5 +1,4 @@
 # Format: WPVERSION_PHPVERSION=PLUGIN:PLUGINVERSION,PLUGIN:PLUGINVERSION
 60_74=woocommerce:7.7.0
-68_82=woocommerce:10.0.4
 69_83=woocommerce:10.3.6
 70_84=woocommerce:10.7.0

--- a/config/wp-plugins.conf
+++ b/config/wp-plugins.conf
@@ -2,3 +2,4 @@
 60_74=woocommerce:7.7.0
 68_82=woocommerce:10.0.4
 69_83=woocommerce:10.3.6
+70_84=woocommerce:10.7.0

--- a/config/wp-version.conf
+++ b/config/wp-version.conf
@@ -1,4 +1,4 @@
 # Format: WPVERSION_PHPVERSION=DOCKER_IMAGE
 60_74=wordpress:6.0-php7.4-apache
-68_82=wordpress:6.8-php8.2-apache
 69_83=wordpress:6.9-php8.3-apache
+70_84=wordpress:beta-7.0-RC2-php8.4-apache

--- a/config/wp-version.conf
+++ b/config/wp-version.conf
@@ -1,4 +1,3 @@
 # Format: WPVERSION_PHPVERSION=DOCKER_IMAGE
 60_74=wordpress:6.0-php7.4-apache
-69_83=wordpress:6.9-php8.3-apache
-70_84=wordpress:beta-7.0-RC2-php8.4-apache
+70_84=wordpress:7.0-php8.4-apache


### PR DESCRIPTION
- Added support for 7.0
- Moved activating pdc-pod after activating dependent plugins
- added 70 and php 8.4 to test matrix