### PR TITLE
Purchase Accessories

### DIFF
--- a/admin/AdminCore.php
+++ b/admin/AdminCore.php
@@ -284,6 +284,17 @@ class AdminCore {
 		return apply_filters( 'pdc_pod_order_item_pdf_url', $pdf_url, $pdc_pod_order_item_id );
 	}
 
+	/**
+	 * Retrieves the preset ID for a given order item.
+	 *
+	 * Falls back to the variation or product preset if the order item has no
+	 * preset metadata directly set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $pdc_pod_order_item_id The WooCommerce order item ID.
+	 * @return string The preset ID, or an empty string if not found.
+	 */
 	public function get_preset_id_by_order_item_id( $pdc_pod_order_item_id ) {
 		$pdc_pod_preset_id = wc_get_order_item_meta( $pdc_pod_order_item_id, Core::get_meta_key( 'preset_id' ), true );
 		if ( empty( $pdc_pod_preset_id ) ) {
@@ -579,6 +590,14 @@ class AdminCore {
 		);
 	}
 
+	/**
+	 * REST callback to purchase all purchasable items in a WooCommerce order.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return \WP_REST_Response|\WP_Error REST response or error.
+	 */
 	public function pdc_purchase_order( \WP_REST_Request $request ) {
 		$order_id = $request->get_param( 'id' );
 
@@ -624,7 +643,7 @@ class AdminCore {
 
 		$pdc_order = $result->order;
 		foreach ( $pdc_order->items as $pdc_order_item ) {
-			$order_item_id = (int) $pdc_order_item->customerReference;
+			$order_item_id = (int) $pdc_order_item->customerReference; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			$order_item    = $order->get_item( $order_item_id );
 
 			if ( $order_item ) {
@@ -637,7 +656,7 @@ class AdminCore {
 		$note = sprintf(
 			/* translators: %s: Print.com order number */
 			__( 'Order purchased at Print.com with order number: %s.', 'pdc-pod' ),
-			$pdc_order->orderNumber
+			$pdc_order->orderNumber // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		);
 		$order->add_order_note( $note );
 
@@ -704,7 +723,7 @@ class AdminCore {
 	 * Sets an order item to 'production' when the webhook event is received.
 	 *
 	 * @since 1.0.0
-	 * @param object $payload   The body of the webhook
+	 * @param object $payload   The body of the webhook.
 	 * @return void
 	 */
 	private function on_webhook_in_production( $payload ) {
@@ -913,7 +932,7 @@ class AdminCore {
 		$note = sprintf(
 			// translators: placeholder is the order number.
 			__( 'Item purchased at Print.com with order number: %s.', 'pdc-pod' ),
-			$pdc_order->orderNumber
+			$pdc_order->orderNumber // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		);
 		$order->add_order_note( $note );
 
@@ -924,6 +943,15 @@ class AdminCore {
 		);
 	}
 
+	/**
+	 * Updates WooCommerce order item metadata after a successful Print.com purchase.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WC_Order_Item $order_item The WooCommerce order item.
+	 * @param object         $pdc_order  The Print.com order response object.
+	 * @return void
+	 */
 	private function update_order_item( $order_item, $pdc_order ) {
 		$order_item->update_meta_data( $this->get_meta_key( 'order' ), $pdc_order );
 		$order_item->update_meta_data( $this->get_meta_key( 'purchase_date' ), gmdate( 'c' ) );
@@ -936,8 +964,8 @@ class AdminCore {
 		$order_item_id  = (string) $order_item->get_id();
 		$pdc_order_item = null;
 		foreach ( $pdc_order->items as $item ) {
-			$item_reference = isset( $item->customerReference ) ? $item->customerReference : '';
-			if ( $item_reference === $order_item_id ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$item_reference = isset( $item->customerReference ) ? $item->customerReference : ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			if ( $item_reference === $order_item_id ) {
 				$pdc_order_item = $item;
 				break;
 			}
@@ -1039,6 +1067,12 @@ class AdminCore {
 		}
 	}
 
+	/**
+	 * REST callback to trigger a download of the plugin log file.
+	 *
+	 * @since 1.2.0
+	 * @return void
+	 */
 	public function download_logs() {
 		$logger = Logger::get_instance();
 		$logger->download_log();

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -25,8 +25,6 @@ use PdcPod\Includes\Logger;
  */
 class APIClient {
 
-
-
 	/**
 	 * Base URL of the Print.com API.
 	 *
@@ -300,13 +298,14 @@ class APIClient {
 	/**
 	 * Retrieves a specific preset by its ID from the Print.com API.
 	 *
-	 * This method fetches the preset details and cleans up the configuration object
-	 * by removing unnecessary API-specific fields like accessories and delivery promises.
+	 * Fetches the preset details, strips internal API-specific fields from the
+	 * configuration, and resolves any attached accessories into a structured list.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $pdc_pod_preset_id The unique identifier for the Print.com preset.
-	 * @return array|\WP_Error Array containing 'sku' and 'options' on success, WP_Error on failure.
+	 * @return array|\WP_Error Array containing 'sku', 'options', and optionally
+	 *                         'accessories' on success, WP_Error on failure.
 	 */
 	private function get_preset_by_id( $pdc_pod_preset_id ) {
 		$result = $this->perform_authenticated_request( 'GET', '/customerpresets/' . rawurlencode( $pdc_pod_preset_id ), null );
@@ -352,8 +351,7 @@ class APIClient {
 		);
 
 		$accessories = array();
-		if ( isset( $preset_config->_accessories ) && ! empty( $preset_config->_accessories ) ) {
-			// loop for accessories and fetch accessory for each key
+		if ( ! empty( $preset_config->_accessories ) ) {
 			foreach ( $preset_config->_accessories as $accessory_id => $quantity ) {
 				$retrieved_accessory = $this->get_accessory_by_id( $preset_decoded->sku, $accessory_id, $quantity );
 				if ( $retrieved_accessory ) {
@@ -361,6 +359,8 @@ class APIClient {
 				}
 			}
 		}
+
+		unset( $preset_config->_accessories );
 
 		if ( ! empty( $accessories ) ) {
 			$preset['accessories'] = $accessories;
@@ -394,11 +394,30 @@ class APIClient {
 			}
 		}
 
+		if ( null === $accessory ) {
+			Logger::log(
+				'accessory not found in product accessories list.',
+				'error',
+				array(
+					'sku'          => $sku,
+					'accessory_id' => $accessory_id,
+				)
+			);
+		}
+
 		return $accessory;
 	}
 
+	/**
+	 * Retrieves all available accessories for a product SKU.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string $sku The product SKU.
+	 * @return array|\WP_Error List of accessory objects on success, WP_Error on failure.
+	 */
 	private function get_product_accessories( $sku ) {
-		$result = $this->perform_authenticated_request( 'GET', '/accessories/' . rawurlencode( $sku ), null );
+		$result = $this->perform_authenticated_request( 'GET', '/accessories/' . rawurlencode( $sku ) );
 		if ( is_wp_error( $result ) ) {
 			Logger::log(
 				'failed to get accessories for product.',
@@ -441,23 +460,26 @@ class APIClient {
 			$preset['options']->copies = $order_item->get_quantity();
 		}
 
+		$shipping_address_payload = array(
+			'email'       => $order->get_billing_email(),
+			'city'        => $shipping_address['city'],
+			'country'     => $shipping_address['country'],
+			'firstName'   => $shipping_address['first_name'],
+			'lastName'    => $shipping_address['last_name'],
+			'companyName' => $shipping_address['company'],
+			'postcode'    => $shipping_address['postcode'],
+			'fullstreet'  => $shipping_address['address_1'],
+			'telephone'   => $shipping_address['phone'],
+		);
+
 		$order_item_shipment = array(
 			array(
-				'address' => array(
-					'email'       => $order->get_billing_email(),
-					'city'        => $shipping_address['city'],
-					'country'     => $shipping_address['country'],
-					'firstName'   => $shipping_address['first_name'],
-					'lastName'    => $shipping_address['last_name'],
-					'companyName' => $shipping_address['company'],
-					'postcode'    => $shipping_address['postcode'],
-					'fullstreet'  => $shipping_address['address_1'],
-					'telephone'   => $shipping_address['phone'],
-				),
+				'address' => $shipping_address_payload,
 				'copies'  => $preset['options']->copies,
 			),
 		);
-		$order_item          = array(
+
+		$prepared_item = array(
 			'sku'               => $preset['sku'],
 			'fileUrl'           => $pdc_pod_pdf_url,
 			'options'           => $preset['options'],
@@ -466,25 +488,26 @@ class APIClient {
 			'shipments'         => $order_item_shipment,
 		);
 
-		if ( isset( $preset['accessories'] ) && is_array( $preset['accessories'] ) ) {
-			$order_item['accessories'] = array();
+		if ( ! empty( $preset['accessories'] ) ) {
+			$prepared_item['accessories'] = array();
 			foreach ( $preset['accessories'] as $accessory ) {
-				$preset_accessory                    = array(
+				$preset_accessory            = array(
 					'sku'         => $accessory->sku,
 					'options'     => $accessory->configuration,
 					'accessoryId' => $accessory->id,
-					'shipments'   => array(),
-				);
-				$preset_accessory['shipments'][]     = array(
-					'address' => $order_item_shipment[0]['address'],
-					'copies'  => $accessory->copies,
+					'shipments'   => array(
+						array(
+							'address' => $shipping_address_payload,
+							'copies'  => $accessory->copies,
+						),
+					),
 				);
 				$preset_accessory['options']->copies = $accessory->copies;
-				$order_item['accessories'][]         = $preset_accessory;
+				$prepared_item['accessories'][]      = $preset_accessory;
 			}
 		}
 
-		return $order_item;
+		return $prepared_item;
 	}
 
 	/**

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Print.com API client (admin)
  *
@@ -11,7 +12,6 @@
 
 namespace PdcPod\Admin\PrintDotCom;
 
-use PdcPod\Includes\Core;
 use PdcPod\Includes\Logger;
 
 /**
@@ -24,6 +24,7 @@ use PdcPod\Includes\Logger;
  * @subpackage Pdc_Pod/admin
  */
 class APIClient {
+
 
 
 	/**
@@ -303,6 +304,7 @@ class APIClient {
 	 * by removing unnecessary API-specific fields like accessories and delivery promises.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @param string $pdc_pod_preset_id The unique identifier for the Print.com preset.
 	 * @return array|\WP_Error Array containing 'sku' and 'options' on success, WP_Error on failure.
 	 */
@@ -339,16 +341,78 @@ class APIClient {
 				)
 			);
 		}
-		$preset        = json_decode( $result );
-		$preset_config = $preset->configuration;
-		unset( $preset_config->_accessories );
+		$preset_decoded = json_decode( $result );
+		$preset_config  = $preset_decoded->configuration;
 		unset( $preset_config->variants );
 		unset( $preset_config->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-		return array(
-			'sku'     => $preset->sku,
+		$preset = array(
+			'sku'     => $preset_decoded->sku,
 			'options' => $preset_config,
 		);
+
+		$accessories = array();
+		if ( isset( $preset_config->_accessories ) && ! empty( $preset_config->_accessories ) ) {
+			// loop for accessories and fetch accessory for each key
+			foreach ( $preset_config->_accessories as $accessory_id => $quantity ) {
+				$retrieved_accessory = $this->get_accessory_by_id( $preset_decoded->sku, $accessory_id, $quantity );
+				if ( $retrieved_accessory ) {
+					$accessories[] = $retrieved_accessory;
+				}
+			}
+		}
+
+		if ( ! empty( $accessories ) ) {
+			$preset['accessories'] = $accessories;
+		}
+
+		return $preset;
+	}
+
+	/**
+	 * Retrieves an accessory by its ID for a specific product SKU.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string $sku          The product SKU.
+	 * @param string $accessory_id The accessory ID to find.
+	 * @param int    $quantity     The quantity of the accessory.
+	 * @return object|null The accessory object, or null if not found.
+	 */
+	private function get_accessory_by_id( $sku, $accessory_id, $quantity ) {
+		$sku_accessories = $this->get_product_accessories( $sku );
+		if ( is_wp_error( $sku_accessories ) || ! is_array( $sku_accessories ) ) {
+			return null;
+		}
+
+		$accessory = null;
+		foreach ( $sku_accessories as $sku_accessory ) {
+			if ( $sku_accessory->id === $accessory_id ) {
+				$accessory         = $sku_accessory;
+				$accessory->copies = $quantity;
+				break;
+			}
+		}
+
+		return $accessory;
+	}
+
+	private function get_product_accessories( $sku ) {
+		$result = $this->perform_authenticated_request( 'GET', '/accessories/' . rawurlencode( $sku ), null );
+		if ( is_wp_error( $result ) ) {
+			Logger::log(
+				'failed to get accessories for product.',
+				'error',
+				array(
+					'sku'         => $sku,
+					'environment' => $this->pdc_pod_api_base_url,
+				)
+			);
+			return new \WP_Error( 500, $result->get_error_message() );
+		}
+
+		$product_accessories = json_decode( $result );
+		return $product_accessories;
 	}
 
 	/**
@@ -377,29 +441,50 @@ class APIClient {
 			$preset['options']->copies = $order_item->get_quantity();
 		}
 
-		return array(
+		$order_item_shipment = array(
+			array(
+				'address' => array(
+					'email'       => $order->get_billing_email(),
+					'city'        => $shipping_address['city'],
+					'country'     => $shipping_address['country'],
+					'firstName'   => $shipping_address['first_name'],
+					'lastName'    => $shipping_address['last_name'],
+					'companyName' => $shipping_address['company'],
+					'postcode'    => $shipping_address['postcode'],
+					'fullstreet'  => $shipping_address['address_1'],
+					'telephone'   => $shipping_address['phone'],
+				),
+				'copies'  => $preset['options']->copies,
+			),
+		);
+		$order_item          = array(
 			'sku'               => $preset['sku'],
 			'fileUrl'           => $pdc_pod_pdf_url,
 			'options'           => $preset['options'],
 			'approveDesign'     => true,
 			'customerReference' => $order_item->get_id(),
-			'shipments'         => array(
-				array(
-					'address' => array(
-						'email'       => $order->get_billing_email(),
-						'city'        => $shipping_address['city'],
-						'country'     => $shipping_address['country'],
-						'firstName'   => $shipping_address['first_name'],
-						'lastName'    => $shipping_address['last_name'],
-						'companyName' => $shipping_address['company'],
-						'postcode'    => $shipping_address['postcode'],
-						'fullstreet'  => $shipping_address['address_1'],
-						'telephone'   => $shipping_address['phone'],
-					),
-					'copies'  => $preset['options']->copies,
-				),
-			),
+			'shipments'         => $order_item_shipment,
 		);
+
+		if ( isset( $preset['accessories'] ) && is_array( $preset['accessories'] ) ) {
+			$order_item['accessories'] = array();
+			foreach ( $preset['accessories'] as $accessory ) {
+				$preset_accessory                    = array(
+					'sku'         => $accessory->sku,
+					'options'     => $accessory->configuration,
+					'accessoryId' => $accessory->id,
+					'shipments'   => array(),
+				);
+				$preset_accessory['shipments'][]     = array(
+					'address' => $order_item_shipment[0]['address'],
+					'copies'  => $accessory->copies,
+				);
+				$preset_accessory['options']->copies = $accessory->copies;
+				$order_item['accessories'][]         = $preset_accessory;
+			}
+		}
+
+		return $order_item;
 	}
 
 	/**

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -210,7 +210,7 @@ class APIClient {
 
 		$presets = array_map(
 			function ( $preset ) {
-				return new Preset( $preset->sku, $preset->title->en, $preset->id );
+				return new Preset( $preset );
 			},
 			$decoded_result->items
 		);
@@ -304,8 +304,7 @@ class APIClient {
 	 * @since 1.0.0
 	 *
 	 * @param string $pdc_pod_preset_id The unique identifier for the Print.com preset.
-	 * @return array|\WP_Error Array containing 'sku', 'options', and optionally
-	 *                         'accessories' on success, WP_Error on failure.
+	 * @return Preset|\WP_Error The preset or WP_Error on failure.
 	 */
 	private function get_preset_by_id( $pdc_pod_preset_id ) {
 		$result = $this->perform_authenticated_request( 'GET', '/customerpresets/' . rawurlencode( $pdc_pod_preset_id ), null );
@@ -340,33 +339,21 @@ class APIClient {
 				)
 			);
 		}
-		$preset_decoded = json_decode( $result );
-		$preset_config  = $preset_decoded->configuration;
-		unset( $preset_config->variants );
-		unset( $preset_config->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$preset = json_decode( $result );
 
-		$preset = array(
-			'sku'     => $preset_decoded->sku,
-			'options' => $preset_config,
-		);
+		$pdc_preset = new Preset($preset);
 
 		$accessories = array();
-		if ( ! empty( $preset_config->_accessories ) ) {
-			foreach ( $preset_config->_accessories as $accessory_id => $quantity ) {
-				$retrieved_accessory = $this->get_accessory_by_id( $preset_decoded->sku, $accessory_id, $quantity );
-				if ( $retrieved_accessory ) {
-					$accessories[] = $retrieved_accessory;
-				}
+		foreach ( $pdc_preset->accessory_ids as $accessory_id => $quantity ) {
+			$retrieved_accessory = $this->get_accessory_by_id( $pdc_preset->sku, $accessory_id, $quantity );
+			if ( $retrieved_accessory ) {
+				$accessories[] = $retrieved_accessory;
 			}
 		}
 
-		unset( $preset_config->_accessories );
+		$pdc_preset->set_accessories($accessories);
 
-		if ( ! empty( $accessories ) ) {
-			$preset['accessories'] = $accessories;
-		}
-
-		return $preset;
+		return $pdc_preset;
 	}
 
 	/**
@@ -377,7 +364,7 @@ class APIClient {
 	 * @param string $sku          The product SKU.
 	 * @param string $accessory_id The accessory ID to find.
 	 * @param int    $quantity     The quantity of the accessory.
-	 * @return object|null The accessory object, or null if not found.
+	 * @return Accessory|null The accessory object, or null if not found.
 	 */
 	private function get_accessory_by_id( $sku, $accessory_id, $quantity ) {
 		$sku_accessories = $this->get_product_accessories( $sku );
@@ -385,16 +372,15 @@ class APIClient {
 			return null;
 		}
 
-		$accessory = null;
+		$pdc_accessory = null;
 		foreach ( $sku_accessories as $sku_accessory ) {
 			if ( $sku_accessory->id === $accessory_id ) {
-				$accessory         = $sku_accessory;
-				$accessory->copies = $quantity;
+				$pdc_accessory = new Accessory( $accessory_id, $sku_accessory->sku, $sku_accessory->configuration, $quantity );
 				break;
 			}
 		}
 
-		if ( null === $accessory ) {
+		if ( null === $pdc_accessory ) {
 			Logger::log(
 				'accessory not found in product accessories list.',
 				'error',
@@ -405,7 +391,7 @@ class APIClient {
 			);
 		}
 
-		return $accessory;
+		return $pdc_accessory;
 	}
 
 	/**
@@ -457,7 +443,7 @@ class APIClient {
 		}
 
 		if ( empty( $purchase_args['use_preset_copies'] ) ) {
-			$preset['options']->copies = $order_item->get_quantity();
+			$preset->set_copies($order_item->get_quantity());
 		}
 
 		$shipping_address_payload = array(
@@ -475,26 +461,26 @@ class APIClient {
 		$order_item_shipment = array(
 			array(
 				'address' => $shipping_address_payload,
-				'copies'  => $preset['options']->copies,
+				'copies'  => $preset->configuration->copies,
 			),
 		);
 
 		$prepared_item = array(
-			'sku'               => $preset['sku'],
+			'sku'               => $preset->sku,
 			'fileUrl'           => $pdc_pod_pdf_url,
-			'options'           => $preset['options'],
+			'options'           => $preset->configuration,
 			'approveDesign'     => true,
 			'customerReference' => $order_item->get_id(),
 			'shipments'         => $order_item_shipment,
 		);
 
-		if ( ! empty( $preset['accessories'] ) ) {
+		if ( ! empty( $preset->accessories ) ) {
 			$prepared_item['accessories'] = array();
-			foreach ( $preset['accessories'] as $accessory ) {
+			foreach ( $preset->accessories as $accessory ) {
 				$preset_accessory            = array(
 					'sku'         => $accessory->sku,
 					'options'     => $accessory->configuration,
-					'accessoryId' => $accessory->id,
+					'accessoryId' => $accessory->accessory_id,
 					'shipments'   => array(
 						array(
 							'address' => $shipping_address_payload,

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -397,12 +397,22 @@ class APIClient {
 	/**
 	 * Retrieves all available accessories for a product SKU.
 	 *
+	 * Results are cached as a transient for one hour to avoid redundant API
+	 * calls when multiple accessories on the same preset are resolved.
+	 *
 	 * @since 1.4.0
+	 * @since 1.4.1 Results are cached using a transient to prevent N+1 API calls.
 	 *
 	 * @param string $sku The product SKU.
 	 * @return array|\WP_Error List of accessory objects on success, WP_Error on failure.
 	 */
 	private function get_product_accessories( $sku ) {
+		$transient_key = PDC_POD_NAME . '-accessories-' . $sku;
+		$cached        = get_transient( $transient_key );
+		if ( $cached ) {
+			return json_decode( $cached );
+		}
+
 		$result = $this->perform_authenticated_request( 'GET', '/accessories/' . rawurlencode( $sku ) );
 		if ( is_wp_error( $result ) ) {
 			Logger::log(
@@ -416,6 +426,7 @@ class APIClient {
 			return new \WP_Error( 500, $result->get_error_message() );
 		}
 
+		set_transient( $transient_key, $result, 60 * 60 ); // 1 hour
 		$product_accessories = json_decode( $result );
 		return $product_accessories;
 	}

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -341,7 +341,7 @@ class APIClient {
 		}
 		$preset = json_decode( $result );
 
-		$pdc_preset = new Preset($preset);
+		$pdc_preset = new Preset( $preset );
 
 		$accessories = array();
 		foreach ( $pdc_preset->accessory_ids as $accessory_id => $quantity ) {
@@ -351,7 +351,7 @@ class APIClient {
 			}
 		}
 
-		$pdc_preset->set_accessories($accessories);
+		$pdc_preset->set_accessories( $accessories );
 
 		return $pdc_preset;
 	}
@@ -454,7 +454,7 @@ class APIClient {
 		}
 
 		if ( empty( $purchase_args['use_preset_copies'] ) ) {
-			$preset->set_copies($order_item->get_quantity());
+			$preset->set_copies( $order_item->get_quantity() );
 		}
 
 		$shipping_address_payload = array(
@@ -488,7 +488,7 @@ class APIClient {
 		if ( ! empty( $preset->accessories ) ) {
 			$prepared_item['accessories'] = array();
 			foreach ( $preset->accessories as $accessory ) {
-				$preset_accessory            = array(
+				$preset_accessory                    = array(
 					'sku'         => $accessory->sku,
 					'options'     => $accessory->configuration,
 					'accessoryId' => $accessory->accessory_id,

--- a/admin/PrintDotCom/APIClient.php
+++ b/admin/PrintDotCom/APIClient.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Print.com API client (admin)
  *
@@ -472,7 +471,7 @@ class APIClient {
 		$order_item_shipment = array(
 			array(
 				'address' => $shipping_address_payload,
-				'copies'  => $preset->configuration->copies,
+				'copies'  => $preset->configuration['copies'],
 			),
 		);
 

--- a/admin/PrintDotCom/Accessory.php
+++ b/admin/PrintDotCom/Accessory.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Print.com Accessory model
+ *
+ * Provides a data structure for representing a Print.com Accessory within the admin context.
+ *
+ * @package Pdc_Pod
+ * @subpackage Pdc_Pod/admin/PrintDotCom
+ * @since 1.6.0
+ */
+
+namespace PdcPod\Admin\PrintDotCom;
+
+/**
+ * Class representing a Print.com Accessory.
+ *
+ * @link       https://print.com
+ * @since      1.6.0
+ *
+ * @package    Pdc_Pod
+ * @subpackage Pdc_Pod/admin
+ */
+class Accessory {
+
+	/**
+	 * The accessory identifier.
+	 *
+	 * @since 1.6.0
+	 * @var string
+	 */
+	public string $accessory_id;
+
+	/**
+	 * The accessory SKU.
+	 *
+	 * @since 1.6.0
+	 * @var string
+	 */
+	public string $sku;
+
+	/**
+	 * The number of copies for this accessory.
+	 *
+	 * @since 1.6.0
+	 * @var int
+	 */
+	public int $copies;
+
+	/**
+	 * The accessory configuration.
+	 *
+	 * @since 1.6.0
+	 * @var object
+	 */
+	public object $configuration;
+
+	/**
+	 * Constructs a new Accessory instance.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param string $accessory_id  The accessory identifier.
+	 * @param string $sku           The accessory SKU.
+	 * @param object $configuration The accessory configuration.
+	 * @param int    $copies        The number of copies.
+	 */
+	public function __construct( $accessory_id, $sku, $configuration, $copies ) {
+		$this->accessory_id  = $accessory_id;
+		$this->sku           = $sku;
+		$this->configuration = $configuration;
+		$this->copies        = $copies;
+	}
+}

--- a/admin/PrintDotCom/Accessory.php
+++ b/admin/PrintDotCom/Accessory.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Print.com Accessory model
  *

--- a/admin/PrintDotCom/Preset.php
+++ b/admin/PrintDotCom/Preset.php
@@ -78,23 +78,22 @@ class Preset {
 	 * @param object $raw_preset   The preset retrieved from the API
 	 */
 	public function __construct( $raw_preset ) {
-		$this->id = $raw_preset->id;
-		$this->sku = $raw_preset->sku;
+		$this->id    = $raw_preset->id;
+		$this->sku   = $raw_preset->sku;
 		$this->title = $raw_preset->title->en;
-		
+
 		$preset_configuration = $raw_preset->configuration;
 		unset( $preset_configuration->variants );
 		unset( $preset_configuration->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		$this->accessory_ids = array();
-		$this->accessories = array();
+		$this->accessories   = array();
 		if ( isset( $preset_configuration->_accessories ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			$this->accessory_ids = (array) $preset_configuration->_accessories; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			unset( $preset_configuration->_accessories ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 
 		$this->configuration = $preset_configuration;
-
 	}
 
 	/**

--- a/admin/PrintDotCom/Preset.php
+++ b/admin/PrintDotCom/Preset.php
@@ -50,9 +50,9 @@ class Preset {
 	 * The preset configuration.
 	 *
 	 * @since 1.0.0
-	 * @var object
+	 * @var array<string, int|string>
 	 */
-	public object $configuration;
+	public array $configuration;
 
 	/**
 	 * Accessory IDs mapped to their quantities.
@@ -75,25 +75,32 @@ class Preset {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param object $raw_preset   The preset retrieved from the API
+	 * @param object $raw_preset   The preset retrieved from the API.
 	 */
 	public function __construct( $raw_preset ) {
-		$this->id    = $raw_preset->id;
-		$this->sku   = $raw_preset->sku;
-		$this->title = $raw_preset->title->en;
-
-		$preset_configuration = $raw_preset->configuration;
-		unset( $preset_configuration->variants );
-		unset( $preset_configuration->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-
+		$this->id            = $raw_preset->id;
+		$this->sku           = $raw_preset->sku;
+		$this->title	     = __( 'Untitled', 'pdc-pod' );
+		$this->configuration = array();
 		$this->accessory_ids = array();
 		$this->accessories   = array();
-		if ( isset( $preset_configuration->_accessories ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			$this->accessory_ids = (array) $preset_configuration->_accessories; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			unset( $preset_configuration->_accessories ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		if (isset($raw_preset->title) && isset($raw_preset->title->en)) {
+			$this->title         = $raw_preset->title->en;
 		}
 
-		$this->configuration = $preset_configuration;
+		if ( isset( $raw_preset->configuration ) ) {
+			$preset_configuration = $raw_preset->configuration;
+			unset( $preset_configuration->variants );
+			unset( $preset_configuration->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			if ( isset( $preset_configuration->_accessories ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$this->accessory_ids = (array) $preset_configuration->_accessories; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				unset( $preset_configuration->_accessories ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			}
+
+			$this->configuration = (array) $preset_configuration;
+		}
 	}
 
 	/**
@@ -115,6 +122,6 @@ class Preset {
 	 * @param int $copies The number of copies.
 	 */
 	public function set_copies( $copies ) {
-		$this->configuration->copies = $copies;
+		$this->configuration['copies'] = $copies;
 	}
 }

--- a/admin/PrintDotCom/Preset.php
+++ b/admin/PrintDotCom/Preset.php
@@ -47,17 +47,75 @@ class Preset {
 	public string $title;
 
 	/**
+	 * The preset configuration.
+	 *
+	 * @since 1.0.0
+	 * @var object
+	 */
+	public object $configuration;
+
+	/**
+	 * Accessory IDs mapped to their quantities.
+	 *
+	 * @since 1.6.0
+	 * @var array<string, int>
+	 */
+	public array $accessory_ids;
+
+	/**
+	 * Resolved accessory objects for this preset.
+	 *
+	 * @since 1.6.0
+	 * @var Accessory[]
+	 */
+	public array $accessories;
+
+	/**
 	 * Constructs a new Preset instance.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $sku   The product SKU.
-	 * @param string $title The preset title.
-	 * @param string $id    The preset identifier.
+	 * @param object $raw_preset   The preset retrieved from the API
 	 */
-	public function __construct( $sku, $title, $id ) {
-		$this->id    = $id;
-		$this->sku   = $sku ?? '';
-		$this->title = $title ?? '';
+	public function __construct( $raw_preset ) {
+		$this->id = $raw_preset->id;
+		$this->sku = $raw_preset->sku;
+		$this->title = $raw_preset->title->en;
+		
+		$preset_configuration = $raw_preset->configuration;
+		unset( $preset_configuration->variants );
+		unset( $preset_configuration->deliveryPromise ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		$this->accessory_ids = array();
+		$this->accessories = array();
+		if ( isset( $preset_configuration->_accessories ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$this->accessory_ids = (array) $preset_configuration->_accessories; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			unset( $preset_configuration->_accessories ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+		$this->configuration = $preset_configuration;
+
+	}
+
+	/**
+	 * Sets the resolved accessories for this preset.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param Accessory[] $accessories The resolved accessories.
+	 */
+	public function set_accessories( $accessories ) {
+		$this->accessories = $accessories;
+	}
+
+	/**
+	 * Overrides the copy count in the configuration.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param int $copies The number of copies.
+	 */
+	public function set_copies( $copies ) {
+		$this->configuration->copies = $copies;
 	}
 }

--- a/admin/partials/pdc-pod-html-order-metabox.php
+++ b/admin/partials/pdc-pod-html-order-metabox.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Admin HTML partial: order metabox
  *
@@ -29,8 +28,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php
 			$pdc_pod_meta_key_pdf_url   = $this->get_meta_key( 'pdf_url' );
 			$pdc_pod_meta_key_preset_id = $this->get_meta_key( 'preset_id' );
-			$items_count                = 0;
-			$items_ready                = 0;
+			$pdc_pod_items_count        = 0;
+			$pdc_pod_items_ready        = 0;
 			foreach ( $order->get_items() as $pdc_pod_order_item_product ) {
 				$pdc_pod_order_item_id          = $pdc_pod_order_item_product->get_id();
 				$pdc_pod_order_item             = wc_get_order_item_meta( $pdc_pod_order_item_id, $this->get_meta_key( 'order_item' ), true );
@@ -48,9 +47,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				$pdc_pod_filename     = basename( $pdc_pod_pdf_url );
 				$pdc_pod_can_purchase = $pdc_pod_has_file && $pdc_pod_has_preset;
 
-				++$items_count;
+				++$pdc_pod_items_count;
 				if ( $pdc_pod_can_purchase && empty( $pdc_pod_purchase_date ) ) {
-					++$items_ready;
+					++$pdc_pod_items_ready;
 				}
 				?>
 				<div class="table-row" id="pdc_order_item_<?php echo esc_attr( $pdc_pod_order_item_id ); ?>">
@@ -58,7 +57,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<div class="table-cell">
 							<?php if ( $pdc_pod_order_item_number ) { ?>
 								<span><strong><?php esc_html_e( 'Order item number', 'pdc-pod' ); ?></strong> #<?php echo esc_html( $pdc_pod_order_item_number ); ?></span><br>
-								<span data-testid="pdc-ordered-copies-<?php echo esc_attr( $items_count ); ?>"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
+								<span data-testid="pdc-ordered-copies-<?php echo esc_attr( $pdc_pod_items_count ); ?>"><strong><?php esc_html_e( 'Copies', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item->options->copies ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Purchase Date', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_purchase_date ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Item Status', 'pdc-pod' ); ?></strong> <?php echo esc_html( $pdc_pod_order_item_status ); ?></span><br>
 								<span><strong><?php esc_html_e( 'Price', 'pdc-pod' ); ?></strong> <?php echo wp_kses_post( wc_price( $pdc_pod_order_item_grand_total ) ); ?></span><br>
@@ -86,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 									<input type="text" class="hidden" id="js-pdc-order-pdf-<?php echo esc_attr( $pdc_pod_order_item_id ); ?>" placeholder="<?php esc_attr_e( 'http://', 'pdc-pod' ); ?>" name="<?php echo esc_attr( $pdc_pod_meta_key_pdf_url ); ?>" value="<?php echo esc_attr( $pdc_pod_pdf_url ); ?>" />
 									<button
 										type="button"
-										id="pdc-file-upload-<?php echo esc_attr( $items_count ); ?>"
+										id="pdc-file-upload-<?php echo esc_attr( $pdc_pod_items_count ); ?>"
 										data-order-item-id="<?php echo esc_attr( $pdc_pod_order_item_id ); ?>"
 										class="button button-secondary js-pdc-file-upload">
 										<?php
@@ -100,8 +99,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 									<button
 										type="button"
-										id="pdc-order-<?php echo esc_attr( $items_count ); ?>"
-										data-testid="pdc-purchase-orderitem-<?php echo esc_attr( $items_count ); ?>"
+										id="pdc-order-<?php echo esc_attr( $pdc_pod_items_count ); ?>"
+										data-testid="pdc-purchase-orderitem-<?php echo esc_attr( $pdc_pod_items_count ); ?>"
 										data-order-item-id="<?php echo esc_attr( $pdc_pod_order_item_id ); ?>"
 										class="button button-primary js-pdc-purchase-orderitem"
 										<?php
@@ -143,17 +142,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 					data-testid="pdc-pod-purchase-all"
 					id="js-pdc-purchase-all"
 					<?php
-					if ( 0 === $items_ready ) {
+					if ( 0 === $pdc_pod_items_ready ) {
 						echo 'disabled';
 					}
 					?>
 					>
 					<?php
-					if ( $items_ready > 0 ) {
-						printf(
-							/* translators: %d: number of items ready for purchase */
-							esc_html( _n( 'Purchase %d item', 'Purchase all %d items', $items_ready, 'pdc-pod' ) ),
-							number_format_i18n( $items_ready )
+					if ( $pdc_pod_items_ready > 0 ) {
+						echo esc_html(
+							sprintf(
+								/* translators: %d: number of items ready for purchase */
+								_n( 'Purchase %d item', 'Purchase all %d items', $pdc_pod_items_ready, 'pdc-pod' ),
+								number_format_i18n( $pdc_pod_items_ready )
+							)
 						);
 					} else {
 						esc_html_e( 'No items to purchase', 'pdc-pod' );

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -122,7 +122,7 @@ class Logger {
 		if ( getenv( 'PDC_POD_API_BASE_URL' ) ) {
 			return getenv( 'PDC_POD_API_BASE_URL' );
 		} else {
-			$env                        = get_option( PDC_POD_NAME . '-env' );
+			$env = get_option( PDC_POD_NAME . '-env' );
 			return ( 'prod' === $env ) ? 'https://api.print.com' : 'https://api.stg.print.com';
 		}
 	}
@@ -134,7 +134,7 @@ class Logger {
 	 */
 	private function get_system_info() {
 		global $wp_version;
-		$theme     = wp_get_theme();
+		$theme = wp_get_theme();
 
 		$info  = "=== System Information ===\n";
 		$info .= 'WordPress Version: ' . $wp_version . "\n";

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -12,6 +12,8 @@
 
 namespace PdcPod\Includes;
 
+use PdcPod\Admin\PrintDotCom\APIClient;
+
 class Logger {
 
 
@@ -119,12 +121,13 @@ class Logger {
 	private function get_system_info() {
 		global $wp_version;
 		$theme = wp_get_theme();
+		$apiclient = new APIClient();
 
 		$info  = "=== System Information ===\n";
 		$info .= 'WordPress Version: ' . $wp_version . "\n";
 		$info .= 'PHP Version: ' . phpversion() . "\n";
 		$info .= 'Plugin Version: ' . PDC_POD_VERSION . "\n";
-		$info .= 'Print.com Environment: ' . get_option( PDC_POD_NAME . '-env' ) . "\n";
+		$info .= 'Print.com Environment: ' . $apiclient->get_api_base_url() . "\n";
 		$info .= 'Server Software: ' . $_SERVER['SERVER_SOFTWARE'] . "\n";
 		$info .= 'Active Theme: ' . $theme->get( 'Name' ) . ' (' . $theme->get( 'Version' ) . ")\n";
 		$info .= 'Multisite: ' . ( is_multisite() ? 'Yes' : 'No' ) . "\n";

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Logger
  *
@@ -12,16 +11,26 @@
 
 namespace PdcPod\Includes;
 
+/**
+ * Singleton logger for the PDC Pod plugin.
+ *
+ * @since 1.2.0
+ */
 class Logger {
 
-
 	/**
-	 * @var Logger The single instance of the class
+	 * The single instance of the class.
+	 *
+	 * @since 1.2.0
+	 * @var Logger
 	 */
 	private static $instance = null;
 
 	/**
-	 * @var string The absolute path to the log file
+	 * The absolute path to the log file.
+	 *
+	 * @since 1.2.0
+	 * @var string
 	 */
 	private $log_file;
 
@@ -39,7 +48,7 @@ class Logger {
 	 * @return Logger
 	 */
 	public static function get_instance() {
-		if ( self::$instance === null ) {
+		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}
 		return self::$instance;
@@ -62,9 +71,9 @@ class Logger {
 		if ( ! file_exists( $dir ) ) {
 			wp_mkdir_p( $dir );
 
-			// Protect the directory from direct browser access
-			file_put_contents( $dir . '/index.php', '<?php // Silence is golden' );
-			file_put_contents( $dir . '/.htaccess', 'Deny from all' );
+			// Protect the directory from direct browser access.
+			file_put_contents( $dir . '/index.php', '<?php // Silence is golden' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			file_put_contents( $dir . '/.htaccess', 'Deny from all' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		}
 	}
 
@@ -108,7 +117,7 @@ class Logger {
 		$context_str = ! empty( $context ) ? ' ' . wp_json_encode( $context ) : '';
 		$log_entry   = "[{$timestamp}] [{$level_str}] {$message}{$context_str}" . PHP_EOL;
 
-		error_log( $log_entry, 3, $instance->log_file );
+		error_log( $log_entry, 3, $instance->log_file ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 
 	/**
@@ -176,7 +185,7 @@ class Logger {
 		$log_content = "=== Print.com Log ===\n";
 
 		if ( file_exists( $this->log_file ) ) {
-			$log_content .= file_get_contents( $this->log_file );
+			$log_content .= file_get_contents( $this->log_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		} else {
 			$log_content .= "No log entries found. The log file does not exist yet.\n";
 		}
@@ -195,7 +204,7 @@ class Logger {
 		header( 'Pragma: public' );
 		header( 'Content-Length: ' . strlen( $final_output ) );
 
-		echo $final_output;
+		echo $final_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		exit;
 	}
 
@@ -205,7 +214,7 @@ class Logger {
 	 */
 	public function clear_log() {
 		if ( file_exists( $this->log_file ) ) {
-			$cleared = file_put_contents( $this->log_file, '' ) !== false;
+			$cleared = file_put_contents( $this->log_file, '' ) !== false; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
 			if ( $cleared ) {
 				self::log( 'Log file manually cleared.', 'debug' );

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -120,7 +120,7 @@ class Logger {
 	 */
 	private function get_system_info() {
 		global $wp_version;
-		$theme = wp_get_theme();
+		$theme     = wp_get_theme();
 		$apiclient = new APIClient();
 
 		$info  = "=== System Information ===\n";

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -12,8 +12,6 @@
 
 namespace PdcPod\Includes;
 
-use PdcPod\Admin\PrintDotCom\APIClient;
-
 class Logger {
 
 
@@ -114,6 +112,22 @@ class Logger {
 	}
 
 	/**
+	 * Resolves the active Print.com API base URL from the environment or plugin settings.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string The API base URL.
+	 */
+	private static function get_environment() {
+		if ( getenv( 'PDC_POD_API_BASE_URL' ) ) {
+			return getenv( 'PDC_POD_API_BASE_URL' );
+		} else {
+			$env                        = get_option( PDC_POD_NAME . '-env' );
+			return ( 'prod' === $env ) ? 'https://api.print.com' : 'https://api.stg.print.com';
+		}
+	}
+
+	/**
 	 * Gathers system information for debugging
 	 *
 	 * @return string
@@ -121,13 +135,12 @@ class Logger {
 	private function get_system_info() {
 		global $wp_version;
 		$theme     = wp_get_theme();
-		$apiclient = new APIClient();
 
 		$info  = "=== System Information ===\n";
 		$info .= 'WordPress Version: ' . $wp_version . "\n";
 		$info .= 'PHP Version: ' . phpversion() . "\n";
 		$info .= 'Plugin Version: ' . PDC_POD_VERSION . "\n";
-		$info .= 'Print.com Environment: ' . $apiclient->get_api_base_url() . "\n";
+		$info .= 'Print.com Environment: ' . Logger::get_environment() . "\n";
 		$info .= 'Server Software: ' . $_SERVER['SERVER_SOFTWARE'] . "\n";
 		$info .= 'Active Theme: ' . $theme->get( 'Name' ) . ' (' . $theme->get( 'Version' ) . ")\n";
 		$info .= 'Multisite: ' . ( is_multisite() ? 'Yes' : 'No' ) . "\n";

--- a/test/e2e/order.spec.ts
+++ b/test/e2e/order.spec.ts
@@ -67,6 +67,35 @@ test.describe('Order', () => {
     await expect(page.getByTestId('pdc-ordered-copies-1')).toHaveText('Copies 1');
   });
 
+  test('will purchase a preset that includes accessories', async ({ page }) => {
+    await setSettings(page, {
+      apikey: 'test_key_12345',
+      env: 'stg',
+      usePresetCopies: true,
+    });
+
+    await configureSimpleProduct(page, '14', 'flyers_a5_with_accessories');
+
+    await addToCart(page, {
+      slug: 'custom-flyers',
+    });
+
+    await placeOrder(page);
+
+    await page.goto('/wp-admin/edit.php?post_type=shop_order');
+
+    await page.locator('table.wp-list-table tbody tr:first-child a.order-view').click();
+
+    await expect(page.getByTestId('pdc-purchase-orderitem-1')).toBeEnabled();
+    const purchaseResponsePromise = page.waitForResponse('**/purchase');
+    await page.getByTestId('pdc-purchase-orderitem-1').click();
+    await purchaseResponsePromise;
+
+    // Verifies the full flow completed: preset fetched, /accessories/flyers called,
+    // order submitted with accessories, and response processed without errors.
+    await expect(page.getByTestId('pdc-ordered-copies-1')).toHaveText('Copies 500');
+  });
+
   test('will purchase multiple order items at once', async ({ page }) => {
     await setSettings(page, {
       apikey: 'test_key_12345',

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -49,7 +49,7 @@ export async function setSettings(page, settings: Settings) {
   await page.getByRole('button', { name: 'Save Settings' }).click();
 }
 
-export async function configureSimpleProduct(page, productID: string) {
+export async function configureSimpleProduct(page, productID: string, presetID: string = 'flyers_a5') {
   const productURL = `/wp-admin/post.php?post=${productID}&action=edit`;
   await page.goto(productURL);
   await page.getByRole('link', { name: 'Print.com' }).click();
@@ -63,7 +63,7 @@ export async function configureSimpleProduct(page, productID: string) {
   });
 
   // select preset
-  await page.getByTestId('pdc-preset-id').selectOption('flyers_a5');
+  await page.getByTestId('pdc-preset-id').selectOption(presetID);
 
   // pdf file = fixture
   await page.getByRole('link', { name: 'Choose file' }).click();

--- a/test/unit/admin/PrintDotCom/test-APIClient.php
+++ b/test/unit/admin/PrintDotCom/test-APIClient.php
@@ -188,6 +188,8 @@ class Test_APIClient extends TestCase {
 			'wp_remote_retrieve_body',
 			[ 'return_in_order' => [ $preset_body, $accessories_body ] ]
 		);
+		WP_Mock::userFunction( 'get_transient', [ 'return' => false ] );
+		WP_Mock::userFunction( 'set_transient', [ 'times' => 1 ] );
 
 		$client     = new APIClient();
 		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
@@ -237,6 +239,8 @@ class Test_APIClient extends TestCase {
 			'wp_remote_retrieve_body',
 			[ 'return_in_order' => [ $preset_body, $accessories_body ] ]
 		);
+		WP_Mock::userFunction( 'get_transient', [ 'return' => false ] );
+		WP_Mock::userFunction( 'set_transient', [ 'times' => 1 ] );
 
 		$client     = new APIClient();
 		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
@@ -269,6 +273,8 @@ class Test_APIClient extends TestCase {
 			'wp_remote_retrieve_body',
 			[ 'return_in_order' => [ $preset_body, $accessories_body ] ]
 		);
+		WP_Mock::userFunction( 'get_transient', [ 'return' => false ] );
+		WP_Mock::userFunction( 'set_transient', [ 'times' => 1 ] );
 
 		$order = \Mockery::mock( 'WC_Order' );
 		$order->shouldReceive( 'get_billing_email' )->andReturn( 'buyer@example.com' );
@@ -312,6 +318,47 @@ class Test_APIClient extends TestCase {
 		$this->assertEquals( 2, $accessory['shipments'][0]['copies'] );
 		$this->assertEquals( 'buyer@example.com', $accessory['shipments'][0]['address']['email'] );
 		$this->assertEquals( 'Amsterdam', $accessory['shipments'][0]['address']['city'] );
+
+		putenv( 'PDC_POD_API_BASE_URL' );
+		putenv( 'PDC_POD_API_KEY' );
+	}
+
+	/**
+	 * Tests that get_preset_by_id calls the accessories endpoint only once
+	 * even when the preset references multiple accessories (N+1 prevention).
+	 *
+	 * @since 1.4.1
+	 */
+	public function test_get_preset_by_id_calls_accessories_api_only_once_for_multiple_accessories() {
+		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
+		putenv( 'PDC_POD_API_KEY=fake-key' );
+
+		$preset_body      = '{"id":"preset-id-123","sku":"poster-a4","title":{"en":"A4 Poster"},"configuration":{"copies":1,"_accessories":{"acc-001":2,"acc-002":1}}}';
+		$accessories_body = '[{"id":"acc-001","sku":"envelope","configuration":{"size":"A4"}},{"id":"acc-002","sku":"tube","configuration":{"size":"A4"}}]';
+
+		// Exactly 2 HTTP calls expected: one for the preset, one for the accessories list.
+		WP_Mock::userFunction( 'wp_remote_request', [ 'times' => 2, 'return' => [] ] );
+		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'return' => 200 ] );
+		WP_Mock::userFunction(
+			'wp_remote_retrieve_body',
+			[ 'return_in_order' => [ $preset_body, $accessories_body ] ]
+		);
+		// First accessory lookup: cache miss; second: cache hit (no further HTTP call).
+		WP_Mock::userFunction(
+			'get_transient',
+			[ 'return_in_order' => [ false, $accessories_body ] ]
+		);
+		WP_Mock::userFunction( 'set_transient', [ 'times' => 1 ] );
+
+		$client     = new APIClient();
+		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
+		$result     = $reflection->invoke( $client, 'preset-id-123' );
+
+		$this->assertInstanceOf( Preset::class, $result );
+		$this->assertCount( 2, $result->accessories );
+		$this->assertEquals( 'acc-001', $result->accessories[0]->accessory_id );
+		$this->assertEquals( 'acc-002', $result->accessories[1]->accessory_id );
 
 		putenv( 'PDC_POD_API_BASE_URL' );
 		putenv( 'PDC_POD_API_KEY' );

--- a/test/unit/admin/PrintDotCom/test-APIClient.php
+++ b/test/unit/admin/PrintDotCom/test-APIClient.php
@@ -13,6 +13,7 @@
 namespace PdcPod\Tests;
 
 use PdcPod\Admin\PrintDotCom\APIClient;
+use PdcPod\Admin\PrintDotCom\Preset;
 use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
@@ -111,11 +112,11 @@ class Test_APIClient extends TestCase {
 
 		$body = json_encode( [
 			'items' => [
-				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster B1' ], 'id' => '1' ],
-				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A2' ], 'id' => '2' ],
-				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A10' ], 'id' => '3' ],
-				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A1' ], 'id' => '4' ],
-				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A0' ], 'id' => '5' ],
+				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster B1' ], 'id' => '1', 'configuration' => [ 'copies' => 1 ] ],
+				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A2' ], 'id' => '2', 'configuration' => [ 'copies' => 1 ] ],
+				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A10' ], 'id' => '3', 'configuration' => [ 'copies' => 1 ] ],
+				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A1' ], 'id' => '4', 'configuration' => [ 'copies' => 1 ] ],
+				[ 'sku' => 'test-posters', 'title' => [ 'en' => 'Poster A0' ], 'id' => '5', 'configuration' => [ 'copies' => 1 ] ],
 			],
 		] );
 
@@ -147,7 +148,7 @@ class Test_APIClient extends TestCase {
 		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
 		putenv( 'PDC_POD_API_KEY=fake-key' );
 
-		$preset_body = '{"sku":"poster-a4","configuration":{"copies":1}}';
+		$preset_body = '{"id":"preset-id-123","sku":"poster-a4","title":{"en":"A4 Poster"},"configuration":{"copies":1}}';
 
 		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
 		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );
@@ -158,11 +159,10 @@ class Test_APIClient extends TestCase {
 		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
 		$result     = $reflection->invoke( $client, 'preset-id-123' );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'sku', $result );
-		$this->assertArrayHasKey( 'options', $result );
-		$this->assertArrayNotHasKey( 'accessories', $result );
-		$this->assertEquals( 'poster-a4', $result['sku'] );
+		$this->assertInstanceOf( Preset::class, $result );
+		$this->assertEquals( 'poster-a4', $result->sku );
+		$this->assertNotEmpty( $result->configuration );
+		$this->assertEmpty( $result->accessories );
 
 		putenv( 'PDC_POD_API_BASE_URL' );
 		putenv( 'PDC_POD_API_KEY' );
@@ -178,7 +178,7 @@ class Test_APIClient extends TestCase {
 		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
 		putenv( 'PDC_POD_API_KEY=fake-key' );
 
-		$preset_body      = '{"sku":"poster-a4","configuration":{"copies":1,"_accessories":{"acc-001":2}}}';
+		$preset_body      = '{"id":"preset-id-123","sku":"poster-a4","title":{"en":"A4 Poster"},"configuration":{"copies":1,"_accessories":{"acc-001":2}}}';
 		$accessories_body = '[{"id":"acc-001","sku":"envelope","configuration":{"size":"A4"}}]';
 
 		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
@@ -193,15 +193,16 @@ class Test_APIClient extends TestCase {
 		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
 		$result     = $reflection->invoke( $client, 'preset-id-123' );
 
-		$this->assertArrayHasKey( 'accessories', $result );
-		$this->assertCount( 1, $result['accessories'] );
+		$this->assertInstanceOf( Preset::class, $result );
+		$this->assertNotEmpty( $result->accessories );
+		$this->assertCount( 1, $result->accessories );
 
-		$resolved = $result['accessories'][0];
-		$this->assertEquals( 'acc-001', $resolved->id );
+		$resolved = $result->accessories[0];
+		$this->assertEquals( 'acc-001', $resolved->accessory_id );
 		$this->assertEquals( 'envelope', $resolved->sku );
 		$this->assertEquals( 2, $resolved->copies );
 
-		$this->assertFalse( property_exists( $result['options'], '_accessories' ) );
+		$this->assertFalse( property_exists( $result->configuration, '_accessories' ) );
 
 		putenv( 'PDC_POD_API_BASE_URL' );
 		putenv( 'PDC_POD_API_KEY' );
@@ -217,7 +218,7 @@ class Test_APIClient extends TestCase {
 		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
 		putenv( 'PDC_POD_API_KEY=fake-key' );
 
-		$preset_body      = '{"sku":"poster-a4","configuration":{"copies":1,"_accessories":{"missing-acc":1}}}';
+		$preset_body      = '{"id":"preset-id-123","sku":"poster-a4","title":{"en":"A4 Poster"},"configuration":{"copies":1,"_accessories":{"missing-acc":1}}}';
 		$accessories_body = '[{"id":"other-acc","sku":"tube","configuration":{}}]';
 
 		// Suppress error-level logging to avoid Logger singleton instantiation.
@@ -241,8 +242,8 @@ class Test_APIClient extends TestCase {
 		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
 		$result     = $reflection->invoke( $client, 'preset-id-123' );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayNotHasKey( 'accessories', $result );
+		$this->assertInstanceOf( Preset::class, $result );
+		$this->assertEmpty( $result->accessories );
 
 		putenv( 'PDC_POD_API_BASE_URL' );
 		putenv( 'PDC_POD_API_KEY' );
@@ -258,7 +259,7 @@ class Test_APIClient extends TestCase {
 		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
 		putenv( 'PDC_POD_API_KEY=fake-key' );
 
-		$preset_body      = '{"sku":"poster-a4","configuration":{"copies":1,"_accessories":{"acc-001":2}}}';
+		$preset_body      = '{"id":"preset-id-123","sku":"poster-a4","title":{"en":"A4 Poster"},"configuration":{"copies":1,"_accessories":{"acc-001":2}}}';
 		$accessories_body = '[{"id":"acc-001","sku":"envelope","configuration":{"size":"A4"}}]';
 
 		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
@@ -326,7 +327,7 @@ class Test_APIClient extends TestCase {
 		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
 		putenv( 'PDC_POD_API_KEY=fake-key' );
 
-		$preset_body = '{"sku":"poster-a4","configuration":{"copies":1}}';
+		$preset_body = '{"id":"preset-id-123","sku":"poster-a4","title":{"en":"A4 Poster"},"configuration":{"copies":1}}';
 
 		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
 		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );

--- a/test/unit/admin/PrintDotCom/test-APIClient.php
+++ b/test/unit/admin/PrintDotCom/test-APIClient.php
@@ -204,7 +204,7 @@ class Test_APIClient extends TestCase {
 		$this->assertEquals( 'envelope', $resolved->sku );
 		$this->assertEquals( 2, $resolved->copies );
 
-		$this->assertFalse( property_exists( $result->configuration, '_accessories' ) );
+		$this->assertArrayNotHasKey( '_accessories', $result->configuration );
 
 		putenv( 'PDC_POD_API_BASE_URL' );
 		putenv( 'PDC_POD_API_KEY' );

--- a/test/unit/admin/PrintDotCom/test-APIClient.php
+++ b/test/unit/admin/PrintDotCom/test-APIClient.php
@@ -136,4 +136,237 @@ class Test_APIClient extends TestCase {
 		putenv( 'PDC_POD_API_BASE_URL' );
 		putenv( 'PDC_POD_API_KEY' );
 	}
+
+	/**
+	 * Tests that get_preset_by_id returns no 'accessories' key when the preset
+	 * configuration contains no _accessories.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_get_preset_by_id_returns_no_accessories_key_when_none_configured() {
+		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
+		putenv( 'PDC_POD_API_KEY=fake-key' );
+
+		$preset_body = '{"sku":"poster-a4","configuration":{"copies":1}}';
+
+		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
+		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'return' => 200 ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body', [ 'return' => $preset_body ] );
+
+		$client     = new APIClient();
+		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
+		$result     = $reflection->invoke( $client, 'preset-id-123' );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'sku', $result );
+		$this->assertArrayHasKey( 'options', $result );
+		$this->assertArrayNotHasKey( 'accessories', $result );
+		$this->assertEquals( 'poster-a4', $result['sku'] );
+
+		putenv( 'PDC_POD_API_BASE_URL' );
+		putenv( 'PDC_POD_API_KEY' );
+	}
+
+	/**
+	 * Tests that get_preset_by_id resolves accessories via a second API call,
+	 * adds them to the result, and strips _accessories from the options object.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_get_preset_by_id_resolves_accessories_and_strips_them_from_options() {
+		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
+		putenv( 'PDC_POD_API_KEY=fake-key' );
+
+		$preset_body      = '{"sku":"poster-a4","configuration":{"copies":1,"_accessories":{"acc-001":2}}}';
+		$accessories_body = '[{"id":"acc-001","sku":"envelope","configuration":{"size":"A4"}}]';
+
+		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
+		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'return' => 200 ] );
+		WP_Mock::userFunction(
+			'wp_remote_retrieve_body',
+			[ 'return_in_order' => [ $preset_body, $accessories_body ] ]
+		);
+
+		$client     = new APIClient();
+		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
+		$result     = $reflection->invoke( $client, 'preset-id-123' );
+
+		$this->assertArrayHasKey( 'accessories', $result );
+		$this->assertCount( 1, $result['accessories'] );
+
+		$resolved = $result['accessories'][0];
+		$this->assertEquals( 'acc-001', $resolved->id );
+		$this->assertEquals( 'envelope', $resolved->sku );
+		$this->assertEquals( 2, $resolved->copies );
+
+		$this->assertFalse( property_exists( $result['options'], '_accessories' ) );
+
+		putenv( 'PDC_POD_API_BASE_URL' );
+		putenv( 'PDC_POD_API_KEY' );
+	}
+
+	/**
+	 * Tests that get_preset_by_id skips an accessory whose ID is absent
+	 * from the product accessories list, and omits the 'accessories' key.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_get_preset_by_id_skips_accessory_not_found_in_product_list() {
+		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
+		putenv( 'PDC_POD_API_KEY=fake-key' );
+
+		$preset_body      = '{"sku":"poster-a4","configuration":{"copies":1,"_accessories":{"missing-acc":1}}}';
+		$accessories_body = '[{"id":"other-acc","sku":"tube","configuration":{}}]';
+
+		// Suppress error-level logging to avoid Logger singleton instantiation.
+		WP_Mock::userFunction(
+			'get_option',
+			[
+				'args'   => [ 'pdc-pod-loglevel', 'error' ],
+				'return' => 'none',
+			]
+		);
+
+		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
+		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'return' => 200 ] );
+		WP_Mock::userFunction(
+			'wp_remote_retrieve_body',
+			[ 'return_in_order' => [ $preset_body, $accessories_body ] ]
+		);
+
+		$client     = new APIClient();
+		$reflection = new \ReflectionMethod( APIClient::class, 'get_preset_by_id' );
+		$result     = $reflection->invoke( $client, 'preset-id-123' );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'accessories', $result );
+
+		putenv( 'PDC_POD_API_BASE_URL' );
+		putenv( 'PDC_POD_API_KEY' );
+	}
+
+	/**
+	 * Tests that prepare_order_item includes a correctly structured
+	 * 'accessories' key when the resolved preset has accessories.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_prepare_order_item_includes_accessories_with_correct_structure() {
+		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
+		putenv( 'PDC_POD_API_KEY=fake-key' );
+
+		$preset_body      = '{"sku":"poster-a4","configuration":{"copies":1,"_accessories":{"acc-001":2}}}';
+		$accessories_body = '[{"id":"acc-001","sku":"envelope","configuration":{"size":"A4"}}]';
+
+		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
+		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'return' => 200 ] );
+		WP_Mock::userFunction(
+			'wp_remote_retrieve_body',
+			[ 'return_in_order' => [ $preset_body, $accessories_body ] ]
+		);
+
+		$order = \Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_billing_email' )->andReturn( 'buyer@example.com' );
+
+		$order_item = \Mockery::mock( 'WC_Order_Item_Product' );
+		$order_item->shouldReceive( 'get_quantity' )->andReturn( 3 );
+		$order_item->shouldReceive( 'get_id' )->andReturn( 99 );
+
+		$shipping_address = [
+			'city'       => 'Amsterdam',
+			'country'    => 'NL',
+			'first_name' => 'John',
+			'last_name'  => 'Doe',
+			'company'    => '',
+			'postcode'   => '1000 AA',
+			'address_1'  => 'Keizersgracht 1',
+			'phone'      => '+31612345678',
+		];
+
+		$client     = new APIClient();
+		$reflection = new \ReflectionMethod( APIClient::class, 'prepare_order_item' );
+		$result     = $reflection->invoke(
+			$client,
+			$order,
+			$order_item,
+			'preset-id-123',
+			'https://example.com/file.pdf',
+			$shipping_address,
+			[]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'accessories', $result );
+		$this->assertCount( 1, $result['accessories'] );
+
+		$accessory = $result['accessories'][0];
+		$this->assertEquals( 'envelope', $accessory['sku'] );
+		$this->assertEquals( 'acc-001', $accessory['accessoryId'] );
+		$this->assertEquals( 2, $accessory['options']->copies );
+		$this->assertCount( 1, $accessory['shipments'] );
+		$this->assertEquals( 2, $accessory['shipments'][0]['copies'] );
+		$this->assertEquals( 'buyer@example.com', $accessory['shipments'][0]['address']['email'] );
+		$this->assertEquals( 'Amsterdam', $accessory['shipments'][0]['address']['city'] );
+
+		putenv( 'PDC_POD_API_BASE_URL' );
+		putenv( 'PDC_POD_API_KEY' );
+	}
+
+	/**
+	 * Tests that prepare_order_item excludes the 'accessories' key when
+	 * the preset has no _accessories configured.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_prepare_order_item_excludes_accessories_key_when_preset_has_none() {
+		putenv( 'PDC_POD_API_BASE_URL=https://testapi.print.com' );
+		putenv( 'PDC_POD_API_KEY=fake-key' );
+
+		$preset_body = '{"sku":"poster-a4","configuration":{"copies":1}}';
+
+		WP_Mock::userFunction( 'wp_remote_request', [ 'return' => [] ] );
+		WP_Mock::userFunction( 'is_wp_error', [ 'return' => false ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'return' => 200 ] );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body', [ 'return' => $preset_body ] );
+
+		$order = \Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_billing_email' )->andReturn( 'buyer@example.com' );
+
+		$order_item = \Mockery::mock( 'WC_Order_Item_Product' );
+		$order_item->shouldReceive( 'get_quantity' )->andReturn( 1 );
+		$order_item->shouldReceive( 'get_id' )->andReturn( 99 );
+
+		$shipping_address = [
+			'city'       => 'Amsterdam',
+			'country'    => 'NL',
+			'first_name' => 'John',
+			'last_name'  => 'Doe',
+			'company'    => '',
+			'postcode'   => '1000 AA',
+			'address_1'  => 'Keizersgracht 1',
+			'phone'      => '+31612345678',
+		];
+
+		$client     = new APIClient();
+		$reflection = new \ReflectionMethod( APIClient::class, 'prepare_order_item' );
+		$result     = $reflection->invoke(
+			$client,
+			$order,
+			$order_item,
+			'preset-id-123',
+			'https://example.com/file.pdf',
+			$shipping_address,
+			[]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'accessories', $result );
+
+		putenv( 'PDC_POD_API_BASE_URL' );
+		putenv( 'PDC_POD_API_KEY' );
+	}
 }

--- a/test/unit/includes/test-Logger.php
+++ b/test/unit/includes/test-Logger.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Test Logger functionality
+ *
+ * Tests for the Logger class, focusing on environment resolution
+ * added in version 1.4.0.
+ *
+ * @package Pdc_Pod
+ * @subpackage Pdc_Pod/tests
+ * @since 1.4.0
+ */
+
+namespace PdcPod\Tests;
+
+use PdcPod\Includes\Logger;
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+
+/**
+ * Logger test case.
+ *
+ * Tests the Logger class.
+ *
+ * @since 1.4.0
+ */
+class Test_Logger extends TestCase {
+
+	public static function setUpBeforeClass(): void {
+		if ( ! defined( 'PDC_POD_NAME' ) ) {
+			define( 'PDC_POD_NAME', 'pdc-pod' );
+		}
+	}
+
+	/**
+	 * Tests that get_environment returns the PDC_POD_API_BASE_URL env var
+	 * when it is set, taking precedence over the stored option.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_get_environment_returns_env_var_when_set() {
+		putenv( 'PDC_POD_API_BASE_URL=https://custom.api.example.com' );
+
+		$reflection = new \ReflectionMethod( Logger::class, 'get_environment' );
+		$result     = $reflection->invoke( null );
+
+		$this->assertEquals( 'https://custom.api.example.com', $result );
+
+		putenv( 'PDC_POD_API_BASE_URL' );
+	}
+
+	/**
+	 * Tests that get_environment returns the production URL when
+	 * the stored environment option is 'prod'.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_get_environment_returns_production_url_when_option_is_prod() {
+		WP_Mock::userFunction(
+			'get_option',
+			[
+				'args'   => [ 'pdc-pod-env' ],
+				'return' => 'prod',
+			]
+		);
+
+		$reflection = new \ReflectionMethod( Logger::class, 'get_environment' );
+		$result     = $reflection->invoke( null );
+
+		$this->assertEquals( 'https://api.print.com', $result );
+	}
+
+	/**
+	 * Tests that get_environment returns the staging URL when
+	 * the stored environment option is not 'prod'.
+	 *
+	 * @since 1.4.0
+	 */
+	public function test_get_environment_returns_staging_url_when_option_is_not_prod() {
+		WP_Mock::userFunction(
+			'get_option',
+			[
+				'args'   => [ 'pdc-pod-env' ],
+				'return' => 'stg',
+			]
+		);
+
+		$reflection = new \ReflectionMethod( Logger::class, 'get_environment' );
+		$result     = $reflection->invoke( null );
+
+		$this->assertEquals( 'https://api.stg.print.com', $result );
+	}
+}

--- a/test/wiremock/__files/accessories.flyers.json
+++ b/test/wiremock/__files/accessories.flyers.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "acc-001",
+    "sku": "envelopes",
+    "configuration": {
+      "size": "a5",
+      "copies": 1
+    }
+  }
+]

--- a/test/wiremock/__files/preset.flyers_a5_with_accessories.json
+++ b/test/wiremock/__files/preset.flyers_a5_with_accessories.json
@@ -1,0 +1,12 @@
+{
+  "id": "flyers_a5_with_accessories",
+  "sku": "flyers",
+  "configuration": {
+    "size": "a5",
+    "copies": 500,
+    "variants": [],
+    "_accessories": {
+      "acc-001": 1
+    }
+  }
+}

--- a/test/wiremock/__files/presets.json
+++ b/test/wiremock/__files/presets.json
@@ -8,6 +8,13 @@
       "id": "flyers_a5"
     },
     {
+      "sku": "flyers",
+      "title": {
+        "en": "A5 Flyers with Envelopes"
+      },
+      "id": "flyers_a5_with_accessories"
+    },
+    {
       "sku": "posters",
       "title": {
         "en": "A2 Posters"

--- a/test/wiremock/mappings/accessories.flyers.get.json
+++ b/test/wiremock/mappings/accessories.flyers.get.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/accessories/flyers",
+    "headers": {
+      "authorization": {
+        "equalTo": "PrintApiKey test_key_12345"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*"
+    },
+    "bodyFileName": "accessories.flyers.json"
+  }
+}

--- a/test/wiremock/mappings/customerpresets.flyers_a5_with_accessories.get.json
+++ b/test/wiremock/mappings/customerpresets.flyers_a5_with_accessories.get.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/customerpresets/flyers_a5_with_accessories",
+    "headers": {
+      "authorization": {
+        "equalTo": "PrintApiKey test_key_12345"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*"
+    },
+    "bodyFileName": "preset.flyers_a5_with_accessories.json"
+  }
+}


### PR DESCRIPTION
Presets can declare `_accessories` in their configuration — products that should be purchased alongside the main item. Previously these were silently stripped. This PR resolves accessories via /accessories/{sku} and includes them in the purchase payload.

Also fixes the logger's environment display to respect the`PDC_POD_API_BASE_URL` env variable instead of always reading from plugin options.

## Changes

`admin/PrintDotCom/APIClient.php`
get_preset_by_id() now resolves _accessories via two new private methods (get_product_accessories, get_accessory_by_id) and returns them alongside sku and options. prepare_order_item() appends an accessories array to the order payload when present, reusing the extracted shipping address for each accessory shipment.

`includes/Logger.php`
Added get_environment() that checks PDC_POD_API_BASE_URL first, falling back to the plugin option.

`test/`
E2e test for the accessories purchase flow, unit tests for APIClient and Logger, and WireMock fixtures for the new preset-with-accessories scenario.

##  Commits
0a2c137 add actual api client env to logger\
31d1e0b add preset accessories to order item\
4014734 review\
977c264 add e2e and unit tests